### PR TITLE
Add pairx to requirements and update explain_router import.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 *.pyc
 .venv/
 __pycache__/
+
+## ide / dev
+.idea/
+.vscode/
+.venv
+.python-version
+
+## ds
+.DS_Store
+Thumbs.db

--- a/app/routers/explain_router.py
+++ b/app/routers/explain_router.py
@@ -1,21 +1,19 @@
-import logging
-from fastapi import APIRouter, UploadFile, File, HTTPException, Request, Depends
-from typing import Optional
-import httpx
 import asyncio
+import logging
 from pathlib import Path
-from app.schemas.model_response import ModelResponse
-import torch
-from torch.utils.data import DataLoader
+
 import cv2
-from pydantic import BaseModel
+import httpx
+import numpy as np
+import torch
 import torchvision.transforms as transforms
 from PIL import Image
-from app.utils.helpers import get_chip_from_img
-from app.utils.pairx.core import explain
-from app.models.model_handler import ModelHandler
-import numpy as np
+from fastapi import APIRouter, HTTPException, Request, Depends
+from pydantic import BaseModel
+from pairx import explain
 
+from app.models.model_handler import ModelHandler
+from app.utils.helpers import get_chip_from_img
 
 logger = logging.getLogger(__name__)
 

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     libgl1-mesa-glx \
     libglib2.0-dev \
     libglib2.0-0 \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Set default timezone

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ typing-extensions==4.12.2
 pyyaml==6.0.1
 PytorchWildlife==1.2.3
 zennit==0.5.1
-git+https://github.com/WildMeOrg/pairx.git@pip-setup#egg=pairx
+git+https://github.com/WildMeOrg/pairx.git#egg=pairx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ typing-extensions==4.12.2
 pyyaml==6.0.1
 PytorchWildlife==1.2.3
 zennit==0.5.1
+git+https://github.com/WildMeOrg/pairx.git@pip-setup#egg=pairx
+


### PR DESCRIPTION
With [accompanying updates to pairx](https://github.com/WildMeOrg/pairx/pull/4) it can now be imported properly and used in explain_router without the currently missing ref. 