### PR TITLE
fix: default prod compose to 1 uvicorn worker per GPU

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -39,7 +39,11 @@ services:
     # Raise MAX_REQUEST_BODY_BYTES only for installations POSTing data URIs.
     # Recommended nginx back-stop in front of this service: client_max_body_size.
     # --limit-concurrency 32 (in-code default) 503s excess connections per worker.
-    command: python3 -m app.main --host 0.0.0.0 --port 6050 --device ${DEVICE:-cuda} --workers ${WORKERS:-4}
+    # One worker per GPU: extra workers each load a full copy of all models
+    # into the same GPU's VRAM (OOM risk). For more throughput, add a separately
+    # named service with distinct GPU_ID, container name, and host port rather
+    # than raising WORKERS.
+    command: python3 -m app.main --host 0.0.0.0 --port 6050 --device ${DEVICE:-cuda} --workers ${WORKERS:-1}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## What

One-line behavior change: `docker-compose.prod.yml` now defaults `WORKERS` to **1** (was 4), plus an explanatory comment.

## Why

Each extra uvicorn worker loads a full copy of all five models into the same GPU's VRAM — an OOM lottery with little throughput gain, since GPU inference dominates request time. The README (`--workers` docs) and the dev compose already document/default **1**; prod at 4 was the outlier contradicting both. `WORKERS` in `.env` still overrides for anyone who has explicitly set it.

For more throughput, add a separately named service with a distinct `GPU_ID`, container name, and host port rather than raising `WORKERS`.

## Provenance

Carved out of #26 as an atomic, independently revertable change (part of splitting that PR into reviewable units). Reviewed by Codex 5.6 (gpt-5.6-terra): 2 rounds, comment wording corrected per its findings ('scale via replicas' was impossible under this compose file's fixed `container_name`/`GPU_ID`), converged with no Major findings.

## Testing

- `pytest tests/` — 42 passed (config-only change; suite verifies no collateral).
- `docker compose -f docker/docker-compose.prod.yml config` interpolation verified (`${WORKERS:-1}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)