### PR TITLE
fix: harden checkpoint downloader for startup-critical fetches

### DIFF
--- a/app/utils/checkpoint_utils.py
+++ b/app/utils/checkpoint_utils.py
@@ -1,11 +1,23 @@
+import contextlib
+import fcntl
+import hashlib
 import os
 import logging
+import queue
+import tempfile
+import threading
 import requests
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+# (connect, read) seconds. The read timeout bounds per-read inactivity only;
+# DOWNLOAD_TOTAL_DEADLINE bounds wall-clock time for the whole fetch (headers
+# included) so a drip-feeding server cannot block startup indefinitely.
+DOWNLOAD_TIMEOUT = (10, 60)
+DOWNLOAD_TOTAL_DEADLINE = 900
 
 def is_url(path: str) -> bool:
     """Check if a path is a URL."""
@@ -27,38 +39,128 @@ def download_checkpoint(url: str, cache_dir: str = "/tmp/checkpoints") -> str:
     """
     # Create cache directory if it doesn't exist
     os.makedirs(cache_dir, exist_ok=True)
-    
-    # Generate filename from URL
+
+    # Key the cache by the full URL, not just the basename, so two stores
+    # serving files with the same name (e.g. .../model.pt) don't collide.
     parsed_url = urlparse(url)
-    filename = os.path.basename(parsed_url.path)
-    if not filename:
-        filename = "checkpoint.pth"
-    
-    local_path = os.path.join(cache_dir, filename)
-    
-    # Check if file already exists
+    basename = os.path.basename(parsed_url.path) or "checkpoint.pth"
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+    local_path = os.path.join(cache_dir, f"{url_hash}_{basename}")
+
     if os.path.exists(local_path):
         logger.info(f"Checkpoint already cached at {local_path}")
         return local_path
-    
-    logger.info(f"Downloading checkpoint from {url}")
-    
+
+    # Serialize downloaders across processes (multiple uvicorn workers or
+    # replicas sharing a cache volume) so only one fetches; the rest wait on
+    # the lock and reuse its result.
+    with open(local_path + ".lock", 'w') as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            if os.path.exists(local_path):
+                logger.info(f"Checkpoint already cached at {local_path}")
+                return local_path
+            return _fetch_to_cache(url, cache_dir, local_path)
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+def _fetch_to_cache(url: str, cache_dir: str, local_path: str) -> str:
+    """Fetch url to local_path, bounding total wall-clock time.
+
+    The socket read timeout only limits per-read inactivity — a server that
+    keeps trickling bytes can hold a blocking read far past any deadline
+    checked between reads. So the fetch runs in a worker thread and the
+    caller waits at most DOWNLOAD_TOTAL_DEADLINE, closing the response to
+    abort the worker on expiry. An aborted worker may linger until its
+    socket timeout fires, but the caller always regains control on time.
+    """
+    result_queue = queue.Queue(maxsize=1)
+    response_holder = {}
+    cancel = threading.Event()
+    # Serializes cancellation against the worker's final check-and-rename so
+    # a checkpoint can never be installed after cancel is set: either the
+    # commit wins (install completed before the deadline path set cancel) or
+    # cancellation wins (no install, ever).
+    commit_lock = threading.Lock()
+
+    def _worker():
+        try:
+            result_queue.put(
+                ("ok", _stream_to_cache(url, cache_dir, local_path,
+                                        response_holder, cancel, commit_lock))
+            )
+        except BaseException as e:
+            result_queue.put(("err", e))
+
+    thread = threading.Thread(target=_worker, daemon=True, name="checkpoint-download")
+    thread.start()
     try:
-        response = requests.get(url, stream=True)
-        response.raise_for_status()
-        
-        with open(local_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-        
+        status, value = result_queue.get(timeout=DOWNLOAD_TOTAL_DEADLINE)
+    except queue.Empty:
+        # Order matters: set cancel before reading the holder. Either we see
+        # the response and close it, or the worker publishes afterwards and
+        # then sees cancel — no interleaving lets it run to completion.
+        with commit_lock:
+            cancel.set()
+        response = response_holder.get("response")
+        if response is not None:
+            with contextlib.suppress(Exception):
+                response.close()
+        logger.error(
+            f"Download of {url} exceeded {DOWNLOAD_TOTAL_DEADLINE}s deadline"
+        )
+        raise TimeoutError(
+            f"Download of {url} exceeded {DOWNLOAD_TOTAL_DEADLINE}s deadline"
+        )
+    if status == "err":
+        raise value
+    return value
+
+def _stream_to_cache(url: str, cache_dir: str, local_path: str,
+                     response_holder: dict, cancel: threading.Event,
+                     commit_lock: threading.Lock) -> str:
+    """Stream url to a temp file, then rename into place so a concurrent
+    reader (or a crash mid-download) never sees a partial file at local_path.
+
+    Checks `cancel` after publishing the response, while streaming, and
+    before the final rename, so a caller that has already timed out can
+    guarantee no checkpoint is installed after it raised.
+    """
+    logger.info(f"Downloading checkpoint from {url}")
+    tmp_path = None
+    try:
+        with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
+            response_holder["response"] = response
+            if cancel.is_set():
+                raise TimeoutError(f"Download of {url} cancelled after deadline")
+            response.raise_for_status()
+
+            fd, tmp_path = tempfile.mkstemp(dir=cache_dir, suffix=".part")
+            try:
+                f = os.fdopen(fd, 'wb')
+            except Exception:
+                os.close(fd)
+                raise
+            with f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if cancel.is_set():
+                        raise TimeoutError(
+                            f"Download of {url} cancelled after deadline"
+                        )
+                    f.write(chunk)
+        with commit_lock:
+            if cancel.is_set():
+                raise TimeoutError(f"Download of {url} cancelled after deadline")
+            os.replace(tmp_path, local_path)
+
         logger.info(f"Checkpoint downloaded and cached at {local_path}")
         return local_path
-        
+
     except Exception as e:
         logger.error(f"Failed to download checkpoint from {url}: {str(e)}")
-        # Clean up partial file if it exists
-        if os.path.exists(local_path):
-            os.remove(local_path)
+        if tmp_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(tmp_path)
         raise
 
 def get_checkpoint_path(checkpoint_path: Optional[str]) -> Optional[str]:

--- a/tests/test_checkpoint_utils.py
+++ b/tests/test_checkpoint_utils.py
@@ -1,0 +1,270 @@
+"""Tests for app.utils.checkpoint_utils download hardening.
+
+The downloader runs at service startup on serverless GPU platforms, so it
+must not hang forever (timeout), must never expose a partially written file
+at the cache path (atomic write), and must not collide when two different
+URLs share a basename (cache key).
+"""
+import os
+
+import pytest
+
+from app.utils import checkpoint_utils
+from app.utils.checkpoint_utils import download_checkpoint, get_checkpoint_path
+
+
+class FakeResponse:
+    """Minimal stand-in for requests.Response streaming."""
+
+    def __init__(self, chunks, on_chunk=None):
+        self._chunks = chunks
+        self._on_chunk = on_chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        for chunk in self._chunks:
+            if self._on_chunk:
+                self._on_chunk()
+            yield chunk
+
+
+def _patch_get(monkeypatch, response_factory, calls):
+    def fake_get(url, stream=True, **kwargs):
+        calls.append({"url": url, "stream": stream, **kwargs})
+        return response_factory(url)
+
+    monkeypatch.setattr(checkpoint_utils.requests, "get", fake_get)
+
+
+def test_download_passes_timeout_to_requests(monkeypatch, tmp_path):
+    calls = []
+    _patch_get(monkeypatch, lambda url: FakeResponse([b"data"]), calls)
+
+    download_checkpoint("https://example.org/models/a.pt", cache_dir=str(tmp_path))
+
+    assert calls, "requests.get was never called"
+    assert calls[0].get("timeout") == checkpoint_utils.DOWNLOAD_TIMEOUT
+    assert checkpoint_utils.DOWNLOAD_TIMEOUT >= (5, 60), (
+        "timeout must leave room for multi-hundred-MB weight files"
+    )
+
+
+def test_cache_path_absent_until_download_completes(monkeypatch, tmp_path):
+    """A concurrent reader must never see a partial file at the cache path."""
+    seen = []
+
+    def snapshot():
+        seen.extend(p.name for p in tmp_path.iterdir())
+
+    calls = []
+    _patch_get(
+        monkeypatch,
+        lambda url: FakeResponse([b"chunk1", b"chunk2"], on_chunk=snapshot),
+        calls,
+    )
+
+    local_path = download_checkpoint(
+        "https://example.org/models/b.pt", cache_dir=str(tmp_path)
+    )
+
+    final_name = os.path.basename(local_path)
+    assert final_name not in seen, (
+        "final cache path existed while the download was still streaming"
+    )
+    with open(local_path, "rb") as f:
+        assert f.read() == b"chunk1chunk2"
+
+
+def test_distinct_urls_with_same_basename_do_not_collide(monkeypatch, tmp_path):
+    calls = []
+    _patch_get(
+        monkeypatch,
+        lambda url: FakeResponse([url.encode()]),
+        calls,
+    )
+
+    path_a = download_checkpoint(
+        "https://bucket-a.example.org/models/model.pt", cache_dir=str(tmp_path)
+    )
+    path_b = download_checkpoint(
+        "https://bucket-b.example.org/models/model.pt", cache_dir=str(tmp_path)
+    )
+
+    assert path_a != path_b
+    with open(path_a, "rb") as f:
+        assert b"bucket-a" in f.read()
+    with open(path_b, "rb") as f:
+        assert b"bucket-b" in f.read()
+
+
+def test_same_url_reuses_cache(monkeypatch, tmp_path):
+    calls = []
+    _patch_get(monkeypatch, lambda url: FakeResponse([b"payload"]), calls)
+
+    url = "https://example.org/models/c.pt"
+    first = download_checkpoint(url, cache_dir=str(tmp_path))
+    second = download_checkpoint(url, cache_dir=str(tmp_path))
+
+    assert first == second
+    assert len(calls) == 1, "cached checkpoint must not be re-downloaded"
+
+
+def test_failed_download_leaves_no_files(monkeypatch, tmp_path):
+    class ExplodingResponse(FakeResponse):
+        def iter_content(self, chunk_size=8192):
+            yield b"partial"
+            raise IOError("connection dropped")
+
+    calls = []
+    _patch_get(monkeypatch, lambda url: ExplodingResponse([]), calls)
+
+    with pytest.raises(Exception):
+        download_checkpoint(
+            "https://example.org/models/d.pt", cache_dir=str(tmp_path)
+        )
+
+    leftovers = [p.name for p in tmp_path.iterdir() if not p.name.endswith(".lock")]
+    assert leftovers == [], "failed download left files behind"
+
+
+def test_download_enforces_total_deadline(monkeypatch, tmp_path):
+    """A server drip-feeding or stalling mid-body must not hold startup
+    hostage. The socket read timeout only bounds per-read inactivity, so the
+    caller must get control back at the wall-clock deadline even while the
+    fetch is blocked inside a read."""
+    import threading
+    import time as real_time
+
+    monkeypatch.setattr(checkpoint_utils, "DOWNLOAD_TOTAL_DEADLINE", 0.2)
+    release = threading.Event()
+
+    class StallingResponse(FakeResponse):
+        def iter_content(self, chunk_size=8192):
+            yield b"first"
+            release.wait(10)  # stall well past the deadline
+            raise IOError("connection aborted")
+
+        def close(self):
+            release.set()
+
+    calls = []
+    _patch_get(monkeypatch, lambda url: StallingResponse([]), calls)
+
+    start = real_time.monotonic()
+    with pytest.raises(TimeoutError):
+        download_checkpoint(
+            "https://example.org/models/slow.pt", cache_dir=str(tmp_path)
+        )
+    elapsed = real_time.monotonic() - start
+    assert elapsed < 5, (
+        f"deadline must bound wall-clock time even during a stalled read "
+        f"(took {elapsed:.1f}s)"
+    )
+
+    # The aborted worker cleans up its partial file once unblocked.
+    release.set()
+    poll_deadline = real_time.monotonic() + 5
+    while real_time.monotonic() < poll_deadline:
+        leftovers = [
+            p.name for p in tmp_path.iterdir() if not p.name.endswith(".lock")
+        ]
+        if not leftovers:
+            break
+        real_time.sleep(0.05)
+    assert leftovers == [], "deadline abort left files behind"
+
+
+def test_timeout_during_header_wait_never_writes_cache(monkeypatch, tmp_path):
+    """If the deadline expires before the server even returns headers, the
+    late-arriving worker must not keep downloading and install a checkpoint
+    after the caller already raised TimeoutError."""
+    import threading
+    import time as real_time
+
+    monkeypatch.setattr(checkpoint_utils, "DOWNLOAD_TOTAL_DEADLINE", 0.2)
+    gate = threading.Event()
+
+    def stalling_get(url, stream=True, **kwargs):
+        gate.wait(10)  # headers arrive only long after the deadline
+        return FakeResponse([b"late-body"])
+
+    monkeypatch.setattr(checkpoint_utils.requests, "get", stalling_get)
+
+    with pytest.raises(TimeoutError):
+        download_checkpoint(
+            "https://example.org/models/late.pt", cache_dir=str(tmp_path)
+        )
+
+    # Release the worker and watch: no cache file may ever materialize.
+    gate.set()
+    watch_until = real_time.monotonic() + 1.5
+    while real_time.monotonic() < watch_until:
+        files = [p.name for p in tmp_path.iterdir() if not p.name.endswith(".lock")]
+        assert all(f.endswith(".part") for f in files), (
+            f"late worker installed a cache file after timeout: {files}"
+        )
+        real_time.sleep(0.05)
+    leftovers = [p.name for p in tmp_path.iterdir() if not p.name.endswith(".lock")]
+    assert leftovers == [], f"late worker left files behind: {leftovers}"
+
+
+def test_concurrent_downloader_waits_and_reuses_result(monkeypatch, tmp_path):
+    """If another process holds the download lock, we block, then reuse the
+    file it produced instead of downloading again."""
+    import fcntl
+    import threading
+
+    url = "https://example.org/models/e.pt"
+    url_hash = checkpoint_utils.hashlib.sha256(url.encode()).hexdigest()
+    local_path = tmp_path / f"{url_hash}_e.pt"
+    lock_path = tmp_path / f"{url_hash}_e.pt.lock"
+
+    calls = []
+    _patch_get(monkeypatch, lambda u: FakeResponse([b"should-not-run"]), calls)
+
+    lock_file = open(lock_path, "w")
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+    result = {}
+
+    def run():
+        result["path"] = download_checkpoint(url, cache_dir=str(tmp_path))
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join(timeout=0.3)
+    assert t.is_alive(), "downloader should be blocked on the lock"
+
+    # Simulate the lock holder finishing its download, then releasing.
+    local_path.write_bytes(b"winner")
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    lock_file.close()
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    assert result["path"] == str(local_path)
+    assert local_path.read_bytes() == b"winner"
+    assert calls == [], "must reuse the other process's file, not re-download"
+
+
+def test_get_checkpoint_path_local_passthrough(tmp_path):
+    ckpt = tmp_path / "weights.bin"
+    ckpt.write_bytes(b"w")
+    assert get_checkpoint_path(str(ckpt)) == str(ckpt)
+
+
+def test_get_checkpoint_path_missing_local_raises():
+    with pytest.raises(FileNotFoundError):
+        get_checkpoint_path("/nonexistent/path/weights.bin")
+
+
+def test_get_checkpoint_path_none_returns_none():
+    assert get_checkpoint_path(None) is None


### PR DESCRIPTION
## What

Hardens `checkpoint_utils.download_checkpoint` — the mechanism behind every URL-configured model weight, which runs during service startup:

- **Wall-clock deadline (15 min) for the whole fetch**, enforced by running the download in a worker thread and bounding the wait — a stalled connection *or* a drip-feeding server can no longer block readiness forever. A socket-level `(10, 60)` connect/read timeout backs it up. On expiry, the response is closed and a cancellation flag (checked after header receipt, per chunk, and under a commit lock before the final rename) guarantees no checkpoint is ever installed after the caller has raised `TimeoutError`.
- **Atomic cache writes**: stream to a temp file, `os.replace()` into place — a concurrent reader or mid-download crash never sees a partial file at the cache path.
- **Cross-process download lock**: per-cache-key `flock` so multiple workers/replicas sharing a cache volume download once and the rest reuse the result.
- **Collision-proof cache key**: `sha256(url)_basename` instead of basename alone — two stores serving `.../model.pt` no longer collide. (Existing old-format cache entries in `/tmp/checkpoints` are simply ignored and re-fetched once.)

## Why

#26 makes `MODEL_BASE=https://...` a first-class deployment mode, which turns this downloader into the critical path for every cold start on serverless GPU platforms. These failure modes (unbounded startup hang, partial-file reads, duplicate concurrent downloads) go from theoretical to routine in that world. The hardening is equally valid for the URL weights prod already uses.

## Testing

Written test-first (TDD): `tests/test_checkpoint_utils.py`, 11 tests — each hardening behavior had a failing test before the code. Includes a genuinely stalling fake server for the deadline path, a threaded flock contention test for the lock path, and a late-header race test. Full suite: **53 passed**.

## Provenance

Carved out of #26 as an atomic change. Adversarially reviewed by Codex 5.6 (gpt-5.6-terra) over **5 rounds**; it drove the wall-clock deadline (vs naive between-chunk checks), the cross-process lock, the cancellation flag, and the commit lock, and explicitly confirmed convergence: no interleaving permits an install after cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)