### PR TITLE
feat: env-driven server config; image honors injected PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,10 +685,21 @@ uvicorn app.main:app --host 0.0.0.0 --port 6050
 
 ### Command Line Options
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--device` | `cuda` | PyTorch device: `cuda`, `cpu`, or `mps` |
-| `--host` | `0.0.0.0` | Bind address |
-| `--port` | `8888` | Listen port |
-| `--workers` | `1` | Uvicorn worker count (use 1 for GPU to avoid VRAM contention) |
-| `--reload` | off | Auto-reload on code changes (development only) |
+Each flag's default comes from an environment variable when set, so the same
+container image runs unmodified across providers (Cloud Run injects `PORT`,
+RunPod/VMs set `DEVICE`, etc.). An explicit CLI flag always beats the
+environment. The Docker image sets `PORT=6050` and `HOST=0.0.0.0`, so
+container behavior is unchanged unless the platform injects its own values.
+
+| Flag | Env var | Default | Description |
+|------|---------|---------|-------------|
+| `--device` | `DEVICE` | `cuda` | PyTorch device: `cuda`, `cpu`, or `mps` |
+| `--host` | `HOST` | `0.0.0.0` | Bind address |
+| `--port` | `PORT` | `8888` (bare) / `6050` (image) | Listen port |
+| `--workers` | `WORKERS` | `1` | Uvicorn worker count (use 1 for GPU to avoid VRAM contention) |
+| `--reload` | — | off | Auto-reload on code changes (development only) |
+
+Malformed integer values (e.g. a Kubernetes service-link `PORT=tcp://...`)
+are ignored with a warning rather than crashing startup; the image health
+check applies the same fallback so it always probes the port the server
+actually bound.

--- a/app/main.py
+++ b/app/main.py
@@ -25,18 +25,39 @@ logger = logging.getLogger(__name__)
 # Create FastAPI app
 app = FastAPI()
 
-# Parse command line arguments
+def _int_env(name: str, fallback: int, minimum: int = 1, maximum: int = None) -> int:
+    """Integer from the environment, tolerating provider-injected junk.
+
+    Some platforms set unusable values (e.g. Kubernetes service-link vars
+    like PORT=tcp://10.0.0.1:80); a config oddity must not crash startup.
+    Bare ASCII digits within [minimum, maximum] only — exactly what the
+    image healthcheck's shell validation accepts, so server and probe never
+    disagree about the port.
+    """
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return fallback
+    if (not (value.isascii() and value.isdecimal())
+            or int(value) < minimum
+            or (maximum is not None and int(value) > maximum)):
+        logger.warning(f"Ignoring invalid {name}={value!r}; using {fallback}")
+        return fallback
+    return int(value)
+
+# Parse command line arguments. Defaults come from the environment so the
+# same image runs unmodified across providers (Cloud Run injects PORT;
+# RunPod/VMs set DEVICE etc.). Explicit CLI flags still override.
 parser = argparse.ArgumentParser(description='FastAPI Model Serving Application')
-parser.add_argument('--device', type=str, default='cuda', 
+parser.add_argument('--device', type=str, default=os.getenv('DEVICE', 'cuda'),
                    help='Device to run the models on (e.g., cpu, cuda, mps)')
-parser.add_argument('--host', type=str, default='0.0.0.0', 
+parser.add_argument('--host', type=str, default=os.getenv('HOST', '0.0.0.0'),
                    help='Host to run the server on')
-parser.add_argument('--port', type=int, default=8888, 
+parser.add_argument('--port', type=int, default=_int_env('PORT', 8888, maximum=65535),
                    help='Port to run the server on')
-parser.add_argument('--reload', action='store_true', 
+parser.add_argument('--reload', action='store_true',
                    help='Enable auto-reload')
-parser.add_argument('--workers', type=int, default=1, 
-                   help='Number of worker processes')
+parser.add_argument('--workers', type=int, default=_int_env('WORKERS', 1),
+                   help='Number of worker processes (keep at 1 per GPU)')
 args = parser.parse_args()
 
 if __name__ == "__main__":

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -37,9 +37,20 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY app/ app/
 COPY vendor/ vendor/
 
+# The app reads these as argparse defaults (app/main.py). Providers that
+# inject their own PORT (e.g. Cloud Run) override the image default, and the
+# server follows — no hardcoded CMD flags to fight.
+ENV PORT=6050
+ENV HOST=0.0.0.0
+
 EXPOSE 6050
 
+# Mirror app/main.py's _int_env: a non-numeric or out-of-range PORT makes
+# the server fall back to 8888, so the probe must follow it or a healthy
+# server gets killed.
 HEALTHCHECK --interval=30s --timeout=15s --start-period=90s --retries=3 \
-    CMD curl -f http://localhost:6050/health || exit 1
+    CMD case "${PORT}" in ''|*[!0-9]*) p=8888;; *) p="${PORT}";; esac; \
+        { [ "${p}" -ge 1 ] && [ "${p}" -le 65535 ]; } || p=8888; \
+        curl -f "http://localhost:${p}/health" || exit 1
 
-CMD ["python3", "-m", "app.main", "--host", "0.0.0.0", "--port", "6050"]
+CMD ["python3", "-m", "app.main"]

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,82 @@
+"""Tests for env-driven server configuration in app.main.
+
+The same container image must run unmodified across providers: Cloud Run
+injects PORT, RunPod/VMs set DEVICE etc. Env vars supply argparse defaults;
+explicit CLI flags still win. app.main parses sys.argv at import time, so
+each probe runs in a subprocess.
+"""
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _probe(attr, env=None, argv=None):
+    """Import app.main in a subprocess and return getattr(main.args, attr)."""
+    child_env = {k: v for k, v in os.environ.items()
+                 if k not in ("PORT", "HOST", "DEVICE", "WORKERS")}
+    child_env.update(env or {})
+    code = (
+        "import sys; "
+        f"sys.argv = ['app.main'] + {argv or []!r}; "
+        "from app import main; "
+        f"print('PROBE:' + str(getattr(main.args, {attr!r})))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, env=child_env, cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    for line in result.stdout.splitlines():
+        if line.startswith("PROBE:"):
+            return line[len("PROBE:"):]
+    raise AssertionError(f"probe output missing: {result.stdout!r}")
+
+
+def test_port_defaults_to_8888_without_env():
+    """Bare-metal default is unchanged (silent breaks forbidden)."""
+    assert _probe("port") == "8888"
+
+
+def test_port_env_supplies_default():
+    assert _probe("port", env={"PORT": "7777"}) == "7777"
+
+
+def test_cli_flag_overrides_port_env():
+    assert _probe("port", env={"PORT": "7777"}, argv=["--port", "7010"]) == "7010"
+
+
+def test_malformed_port_env_falls_back():
+    """Providers sometimes inject junk (k8s service links); never crash."""
+    assert _probe("port", env={"PORT": "tcp://10.0.0.1:80"}) == "8888"
+
+
+def test_whitespace_padded_port_env_falls_back():
+    """Only bare ASCII digits are accepted, exactly matching the image
+    healthcheck's shell validation — the server and probe must never
+    disagree about the bound port."""
+    assert _probe("port", env={"PORT": " 7777 "}) == "8888"
+
+
+def test_empty_port_env_falls_back():
+    assert _probe("port", env={"PORT": ""}) == "8888"
+
+
+def test_out_of_range_port_env_falls_back():
+    """Ports outside 1-65535 can't serve traffic; fall back like other junk."""
+    assert _probe("port", env={"PORT": "0"}) == "8888"
+    assert _probe("port", env={"PORT": "65536"}) == "8888"
+
+
+def test_device_env_supplies_default():
+    assert _probe("device", env={"DEVICE": "cpu"}) == "cpu"
+
+
+def test_host_env_supplies_default():
+    assert _probe("host", env={"HOST": "127.0.0.1"}) == "127.0.0.1"
+
+
+def test_workers_env_supplies_default():
+    assert _probe("workers", env={"WORKERS": "2"}) == "2"


### PR DESCRIPTION
## What

Makes the container's runtime config env-driven so the same image runs unmodified across providers:

- `app/main.py`: argparse defaults come from `DEVICE` / `HOST` / `PORT` / `WORKERS`; explicit CLI flags still win. Integer envs are validated (bare ASCII digits, port range 1–65535) and fall back with a warning instead of crashing on provider-injected junk like k8s service-link `PORT=tcp://...`.
- `docker/dockerfile`: `CMD` no longer hardcodes `--host`/`--port` (which silently defeated any platform-injected `PORT`, e.g. Cloud Run's); instead `ENV PORT=6050 HOST=0.0.0.0` preserves image behavior exactly. The `HEALTHCHECK` applies the same validation/fallback as `_int_env`, so server and probe can never disagree about the bound port.
- Bare-metal default port stays **8888** — no silent break for `python3 -m app.main`.
- README command-line table updated with the env-var column and precedence rules.

Both compose files pass explicit flags and are unaffected.

## Why

This is the load-bearing 'portability contract' piece of #26, carved out atomically: without the CMD change, the env-driven PORT never engages in the shipped image; with it, Cloud Run / RunPod / VM all configure the container purely via environment.

## Testing

TDD: `tests/test_env_config.py` — 10 subprocess probes (`app.main` parses argv at import) covering env defaults, CLI-over-env precedence, malformed/whitespace/out-of-range fallbacks, and the unchanged bare default. Full suite passes (42 existing + 10 new). Healthcheck shell logic verified against `6050` / empty / `tcp://` junk / whitespace / `0` / `65536` inputs — matches `_int_env` on all.

## Provenance

Carved out of #26. Adversarially reviewed by Codex 5.6 (gpt-5.6-terra), 3 rounds: it drove the healthcheck/server port-validation mirroring (its round-1 Major), the whitespace-exactness fix, and the port-range validation; each fix is pinned by tests. Note: the image hasn't been rebuilt in CI here — the dockerfile change wants one smoke build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)