### PR TITLE
feat: add densenet-wilddog-cascade model type for African wild dog labeling

### DIFF
--- a/app/models/densenet_wilddog_cascade.py
+++ b/app/models/densenet_wilddog_cascade.py
@@ -1,0 +1,326 @@
+"""African wild dog body/tail labeler cascade.
+
+Ports WBIA's three-model wild dog labeler (wbia/core_annots.py:2163-2233),
+which is special-cased there for the single tag string
+``wilddog_v3+wilddog_v2+wilddog_v1`` — every other multi-tag string raises
+NotImplementedError in WBIA, so wild dog is the only species that uses it.
+
+This is NOT an ensemble. The three models play distinct roles and vote:
+
+  router (v3)     decides body vs tail, and supplies the tail class
+  coat (v1)       supplies the body coat class
+  viewpoint (v2)  supplies the body viewpoint
+
+The router gates; the other two must agree with it or the annotation is
+labelled ambiguous. ``wild_dog_ambiguous`` / ``wild_dog+tail_ambiguous``
+exist only as this disagreement output — no individual model has an
+"ambiguous" class — which is why ACW's IA.json declares them as iaClasses.
+
+Why the roles are split this way is visible in the label spaces:
+  v1 carries coat classes but only 3 viewpoints (left/other/right)
+  v2 carries only plain wild_dog but 14 viewpoints (front, backleft, ...)
+  v3 carries the 8 tail classes plus the wild_dog:ignore body gate
+so the viewpoint is taken from v2 and the coat from v1 deliberately.
+
+Each role is itself a 3-head DenseNetClassifierModel ensemble, so all
+checkpoint loading, preprocessing and softmax-averaging is reused from
+there rather than reimplemented.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from app.models.base_model import BaseModel
+from app.models.densenet_classifier import DenseNetClassifierModel
+
+logger = logging.getLogger(__name__)
+
+# Body coat classes emitted by the coat (v1) model. Mirrors flag1 in
+# core_annots.py:2188-2194 — order irrelevant, membership is the test.
+BODY_COAT_CLASSES = frozenset({
+    "wild_dog_dark",
+    "wild_dog_general",
+    "wild_dog_puppy",
+    "wild_dog_standard",
+    "wild_dog_tan",
+})
+
+# Species the viewpoint (v2) model emits for a body — flag2, line 2195.
+VIEWPOINT_BODY_CLASSES = frozenset({"wild_dog", "wild_dog_puppy"})
+
+# Species the router (v3) model emits for a body — flag3, line 2196.
+ROUTER_BODY_CLASSES = frozenset({"wild_dog"})
+
+# Labels each role must expose, used to fail fast on a mis-wired config.
+#
+# These are deliberately per-role *distinguishing* sets, not just "some body
+# class": v2 and v3 BOTH emit the raw species `wild_dog`, so a species-level
+# check cannot tell a router/viewpoint swap apart. The discriminators are:
+#   - only v2 has rich body viewpoints (`wild_dog:front`)
+#   - only v3 has the tail_triple_black / tail_double_* classes
+#   - only v1 has the coat classes
+# Each set also covers every class the decision table actually reads, so a
+# truncated or partially-trained checkpoint is rejected rather than silently
+# never firing a branch. Extra labels (e.g. v1/v2 tail classes, which the
+# cascade ignores) are allowed — these are subset checks.
+ROUTER_REQUIRED_LABELS = frozenset({
+    "wild_dog:ignore",
+    "wild_dog+tail_double_black_brown:ignore",
+    "wild_dog+tail_double_black_white:ignore",
+    "wild_dog+tail_general:ignore",
+    "wild_dog+tail_long_black:ignore",
+    "wild_dog+tail_long_white:ignore",
+    "wild_dog+tail_short_black:ignore",
+    "wild_dog+tail_standard:ignore",
+    "wild_dog+tail_triple_black:ignore",
+})
+
+COAT_REQUIRED_LABELS = frozenset({
+    "wild_dog_dark:left", "wild_dog_dark:other", "wild_dog_dark:right",
+    "wild_dog_general:left", "wild_dog_general:other", "wild_dog_general:right",
+    "wild_dog_standard:left", "wild_dog_standard:other", "wild_dog_standard:right",
+    "wild_dog_tan:left", "wild_dog_tan:other", "wild_dog_tan:right",
+    "wild_dog_puppy:ignore",
+})
+
+VIEWPOINT_REQUIRED_LABELS = frozenset({
+    "wild_dog:back", "wild_dog:backleft", "wild_dog:backright",
+    "wild_dog:down", "wild_dog:front", "wild_dog:frontleft",
+    "wild_dog:frontright", "wild_dog:left", "wild_dog:right",
+    "wild_dog:up", "wild_dog:upback", "wild_dog:upfront",
+    "wild_dog:upleft", "wild_dog:upright",
+    "wild_dog_puppy:ignore",
+})
+
+REQUIRED_LABELS = {
+    "router": (ROUTER_REQUIRED_LABELS, "the v3 tail/body-gate model"),
+    "coat": (COAT_REQUIRED_LABELS, "the v1 coat model"),
+    "viewpoint": (VIEWPOINT_REQUIRED_LABELS, "the v2 viewpoint model"),
+}
+
+# Config keys accepted inside each role object. Anything else is a typo and
+# would otherwise be silently swallowed by DenseNetClassifierModel.load(**kwargs).
+ROLE_CONFIG_KEYS = frozenset({
+    "checkpoint_path", "checkpoint_paths", "img_size", "compound_labels",
+    "label_map", "sentinel_prefixes", "ensemble_indices",
+})
+
+AMBIGUOUS_BODY = "wild_dog_ambiguous"
+AMBIGUOUS_TAIL = "wild_dog+tail_ambiguous"
+AMBIGUOUS_VIEWPOINT = "ambiguous"
+TAIL_VIEWPOINT = "ignore"
+
+ROLES = ("router", "coat", "viewpoint")
+
+
+def _is_compound_label(label: str) -> bool:
+    """True iff `label` is exactly `<species>:<viewpoint>`, both halves set.
+
+    parse_class_label() splits on the FIRST colon, so 'a:b:c' would silently
+    yield viewpoint='b:c' and ':ignore' would yield species=''. Neither is a
+    label this cascade's decision table can reason about.
+    """
+    parts = label.split(":")
+    return len(parts) == 2 and all(p.strip() for p in parts)
+
+
+class DenseNetWildDogCascadeModel(BaseModel):
+    """Three-model role-based cascade for African wild dog annotations."""
+
+    def __init__(self):
+        super().__init__()
+        self.members: Dict[str, DenseNetClassifierModel] = {}
+        self.img_size: int = 224
+        self.model_id: str = ""
+        self.device: str = "cpu"
+
+    def load(self, model_path: str = "", device: str = "cpu",
+             model_id: str = "",
+             router: Optional[Dict[str, Any]] = None,
+             coat: Optional[Dict[str, Any]] = None,
+             viewpoint: Optional[Dict[str, Any]] = None,
+             img_size: int = 224,
+             **kwargs) -> None:
+        # Nothing is written to self until members are built AND validated:
+        # a failed reload of an already-loaded instance must not leave the old
+        # members paired with the new metadata.
+        if kwargs:
+            raise ValueError(
+                f"densenet-wilddog-cascade '{model_id}': unknown config key(s) "
+                f"{sorted(kwargs)}. Expected: router, coat, viewpoint, img_size."
+            )
+
+        specs = {"router": router, "coat": coat, "viewpoint": viewpoint}
+        missing = [r for r in ROLES if not specs[r]]
+        if missing:
+            raise ValueError(
+                f"densenet-wilddog-cascade '{model_id}' is missing required "
+                f"role config(s): {missing}. Each of {list(ROLES)} must be an "
+                f"object with checkpoint_path or checkpoint_paths."
+            )
+
+        # Build into a local dict so a failure part-way through cannot leave
+        # this instance holding a half-wired cascade.
+        members: Dict[str, DenseNetClassifierModel] = {}
+        for role in ROLES:
+            spec = dict(specs[role])
+            unknown = set(spec) - ROLE_CONFIG_KEYS
+            if unknown:
+                raise ValueError(
+                    f"densenet-wilddog-cascade '{model_id}': role '{role}' has "
+                    f"unknown config key(s) {sorted(unknown)}. Expected any of: "
+                    f"{sorted(ROLE_CONFIG_KEYS)}."
+                )
+            member = DenseNetClassifierModel()
+            member.load(
+                device=device,
+                model_id=f"{model_id}[{role}]",
+                checkpoint_path=spec.pop("checkpoint_path", None),
+                checkpoint_paths=spec.pop("checkpoint_paths", None),
+                img_size=spec.pop("img_size", img_size),
+                # Every wild dog label is `<species>:<viewpoint>`; the cascade
+                # reads the parsed species/viewpoint back off each member.
+                compound_labels=spec.pop("compound_labels", True),
+                **spec,
+            )
+            members[role] = member
+
+        self._validate_roles(members, model_id)
+
+        # Commit all state together, only once everything above succeeded.
+        self.members = members
+        self.model_id = model_id
+        self.device = device
+        self.img_size = img_size
+
+        logger.info(
+            f"Loaded DenseNetWildDogCascadeModel '{model_id}': "
+            + ", ".join(
+                f"{r}={len(self.members[r].label_map)} classes" for r in ROLES
+            )
+        )
+
+    def _validate_roles(self, members: Dict[str, DenseNetClassifierModel],
+                        model_id: str) -> None:
+        """Fail fast if the checkpoint sets are wired to the wrong roles.
+
+        The v1/v2/v3 archives look alike on disk and a swap would silently
+        mislabel every annotation rather than error, so each role must expose
+        the labels that distinguish its model AND every label the decision
+        table reads. Checking raw species is NOT sufficient: v2 and v3 both
+        emit species `wild_dog`, so a router/viewpoint swap would pass.
+        """
+        for role in ROLES:
+            labels = set(members[role].label_map.values())
+
+            # Members load with compound_labels=True, so parse_class_label()
+            # must yield a usable (species, viewpoint) for every label. A
+            # colon-free label yields species=None and would silently fail every
+            # branch flag; an empty half or a second colon means the label isn't
+            # what this cascade's decision table assumes. Reject at load rather
+            # than at the first prediction.
+            malformed = sorted(l for l in labels if not _is_compound_label(l))
+            if malformed:
+                raise ValueError(
+                    f"densenet-wilddog-cascade '{model_id}': role '{role}' has "
+                    f"non-compound label(s) {malformed}; every wild dog label "
+                    f"must be exactly '<species>:<viewpoint>' with both halves "
+                    f"non-empty."
+                )
+
+            required, description = REQUIRED_LABELS[role]
+            absent = required - labels
+            if absent:
+                raise ValueError(
+                    f"densenet-wilddog-cascade '{model_id}': role '{role}' "
+                    f"is missing {len(absent)} label(s) required of "
+                    f"{description}: {sorted(absent)[:5]}"
+                    f"{' ...' if len(absent) > 5 else ''}. Its label space is "
+                    f"{sorted(labels)}. Check that the correct checkpoints are "
+                    f"assigned to each role."
+                )
+
+    def predict(self, image_bytes: bytes,
+                bbox: Optional[List[int]] = None,
+                theta: float = 0.0,
+                **kwargs) -> Dict[str, Any]:
+        tops = {}
+        for role in ROLES:
+            result = self.members[role].predict(
+                image_bytes, bbox=bbox, theta=theta
+            )
+            tops[role] = result["predictions"][0]
+
+        router_top = tops["router"]
+        coat_top = tops["coat"]
+        viewpoint_top = tops["viewpoint"]
+
+        # flag1/flag2/flag3 in core_annots.py:2188-2196.
+        coat_is_body = coat_top["species"] in BODY_COAT_CLASSES
+        viewpoint_is_body = viewpoint_top["species"] in VIEWPOINT_BODY_CLASSES
+        router_is_body = router_top["species"] in ROUTER_BODY_CLASSES
+
+        # WBIA averages the three member confidences — np.mean, line 2198.
+        score = (
+            coat_top["probability"]
+            + viewpoint_top["probability"]
+            + router_top["probability"]
+        ) / 3.0
+
+        # Decision table — core_annots.py:2200-2217.
+        if router_is_body:
+            if coat_is_body and viewpoint_is_body:
+                species = coat_top["species"]
+                view = viewpoint_top["viewpoint"]
+            else:
+                species = AMBIGUOUS_BODY
+                view = AMBIGUOUS_VIEWPOINT
+        else:
+            if not coat_is_body and not viewpoint_is_body:
+                species = router_top["species"]
+                view = TAIL_VIEWPOINT
+            else:
+                species = AMBIGUOUS_TAIL
+                view = AMBIGUOUS_VIEWPOINT
+
+        label = f"{species}:{view}"
+
+        return {
+            "model_id": self.model_id,
+            "class": label,
+            "probability": score,
+            # The verdict is synthesized from three label spaces, so no single
+            # member index describes it. -1 marks it as having no class index.
+            "class_id": -1,
+            "predictions": [{
+                "label": label,
+                "probability": score,
+                "index": -1,
+                "species": species,
+                "viewpoint": view,
+            }],
+            # Per-member verdicts, for debugging a surprising cascade result.
+            "cascade": {
+                role: {
+                    "label": tops[role]["label"],
+                    "species": tops[role]["species"],
+                    "viewpoint": tops[role]["viewpoint"],
+                    "probability": tops[role]["probability"],
+                }
+                for role in ROLES
+            },
+        }
+
+    def get_model_info(self) -> Dict[str, Any]:
+        return {
+            "model_type": "densenet-wilddog-cascade",
+            "device": str(self.device),
+            "img_size": self.img_size,
+            "members": {
+                role: {
+                    "num_classes": len(self.members[role].label_map),
+                    "ensemble_size": len(self.members[role].models),
+                    "label_map": self.members[role].label_map,
+                }
+                for role in ROLES
+            },
+        }

--- a/app/models/model_handler.py
+++ b/app/models/model_handler.py
@@ -31,6 +31,10 @@ MODEL_REGISTRY = {
         'module': 'app.models.densenet_classifier',
         'class': 'DenseNetClassifierModel'
     },
+    'densenet-wilddog-cascade': {
+        'module': 'app.models.densenet_wilddog_cascade',
+        'class': 'DenseNetWildDogCascadeModel'
+    },
     'lightnet': {
         'module': 'app.models.lightnet_model',
         'class': 'LightNetModel'

--- a/app/routers/pipeline_router.py
+++ b/app/routers/pipeline_router.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from app.models.model_handler import ModelHandler
 from app.models.efficientnet import EfficientNetModel
 from app.models.densenet_classifier import DenseNetClassifierModel
+from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
 from app.models.miewid import MiewidModel
 from app.models.densenet_orientation import DenseNetOrientationModel
 from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_response, sanitize_uri_for_logging
@@ -91,11 +92,13 @@ async def run_pipeline(
                 )
             
             # Validate model types
-            if not isinstance(classify_model, (EfficientNetModel, DenseNetClassifierModel)):
+            if not isinstance(classify_model, (EfficientNetModel, DenseNetClassifierModel,
+                                              DenseNetWildDogCascadeModel)):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Model '{pipeline_request.classify_model_id}' must be "
-                           f"EfficientNet or DenseNet-classifier for the classify slot."
+                           f"EfficientNet, DenseNet-classifier or DenseNet-wilddog-cascade "
+                           f"for the classify slot."
                 )
             
             if not isinstance(extract_model, MiewidModel):

--- a/tests/test_densenet_wilddog_cascade.py
+++ b/tests/test_densenet_wilddog_cascade.py
@@ -1,0 +1,441 @@
+"""Loader + decision-table tests for DenseNetWildDogCascadeModel.
+
+The decision table is a direct port of WBIA's wild dog labeler
+(wbia/core_annots.py:2200-2217); these tests pin every branch of it so a
+future refactor can't silently change ACW's labelling behaviour.
+
+Like test_densenet_classifier.py, we mock torch.load rather than ship real
+DenseNet weights.
+"""
+from collections import OrderedDict
+from unittest.mock import patch
+
+import pytest
+import torch
+
+# Real label spaces, read off the actual ACW checkpoints.
+V1_COAT_CLASSES = [
+    "wild_dog+tail_general:ignore",
+    "wild_dog+tail_long_black:ignore",
+    "wild_dog+tail_long_white:ignore",
+    "wild_dog+tail_multi_black:ignore",
+    "wild_dog+tail_short_black:ignore",
+    "wild_dog+tail_standard:ignore",
+    "wild_dog_dark:left", "wild_dog_dark:other", "wild_dog_dark:right",
+    "wild_dog_general:left", "wild_dog_general:other", "wild_dog_general:right",
+    "wild_dog_puppy:ignore",
+    "wild_dog_standard:left", "wild_dog_standard:other", "wild_dog_standard:right",
+    "wild_dog_tan:left", "wild_dog_tan:other", "wild_dog_tan:right",
+]
+
+V2_VIEWPOINT_CLASSES = [
+    "wild_dog+tail_general:ignore",
+    "wild_dog+tail_long:ignore",
+    "wild_dog+tail_multi_black:ignore",
+    "wild_dog+tail_short_black:ignore",
+    "wild_dog+tail_standard:ignore",
+    "wild_dog:back", "wild_dog:backleft", "wild_dog:backright",
+    "wild_dog:down", "wild_dog:front", "wild_dog:frontleft",
+    "wild_dog:frontright", "wild_dog:left", "wild_dog:right",
+    "wild_dog:up", "wild_dog:upback", "wild_dog:upfront",
+    "wild_dog:upleft", "wild_dog:upright",
+    "wild_dog_puppy:ignore",
+]
+
+V3_ROUTER_CLASSES = [
+    "wild_dog+tail_double_black_brown:ignore",
+    "wild_dog+tail_double_black_white:ignore",
+    "wild_dog+tail_general:ignore",
+    "wild_dog+tail_long_black:ignore",
+    "wild_dog+tail_long_white:ignore",
+    "wild_dog+tail_short_black:ignore",
+    "wild_dog+tail_standard:ignore",
+    "wild_dog+tail_triple_black:ignore",
+    "wild_dog:ignore",
+]
+
+_PATCH_CKPT = "app.models.densenet_classifier.get_checkpoint_path"
+
+
+def _fake_densenet_state(classes) -> dict:
+    state = OrderedDict()
+    state["classifier.weight"] = torch.zeros(len(classes), 1920)
+    state["classifier.bias"] = torch.zeros(len(classes))
+    return {"state": state, "classes": list(classes)}
+
+
+def _role(path_marker, classes, heads=3):
+    return {"checkpoint_paths": [f"/fake/{path_marker}/labeler.{i}.weights"
+                                for i in range(heads)]}
+
+
+def _torch_load_by_path(mapping):
+    """Return a torch.load side_effect that picks a fake checkpoint by path.
+
+    Markers are matched longest-first: short markers are substrings of longer
+    ones ('v1' is inside 'v1trunc'), and matching in dict order would silently
+    hand back the wrong fixture.
+    """
+    ordered = sorted(mapping.items(), key=lambda kv: -len(kv[0]))
+    def _load(path, *args, **kwargs):
+        for marker, classes in ordered:
+            if marker in str(path):
+                return _fake_densenet_state(classes)
+        raise AssertionError(f"unexpected checkpoint path: {path}")
+    return _load
+
+
+DEFAULT_MAPPING = {
+    "v1": V1_COAT_CLASSES,
+    "v2": V2_VIEWPOINT_CLASSES,
+    "v3": V3_ROUTER_CLASSES,
+}
+
+
+def _load_cascade(mapping=None, **overrides):
+    from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
+    mapping = mapping or DEFAULT_MAPPING
+    spec = {
+        "router": _role("v3", V3_ROUTER_CLASSES),
+        "coat": _role("v1", V1_COAT_CLASSES),
+        "viewpoint": _role("v2", V2_VIEWPOINT_CLASSES),
+    }
+    spec.update(overrides)
+    with patch("torch.load", side_effect=_torch_load_by_path(mapping)), \
+         patch(_PATCH_CKPT, side_effect=lambda p: p):
+        m = DenseNetWildDogCascadeModel()
+        m.load(model_id="wd-cascade", device="cpu", **spec)
+    return m
+
+
+# --------------------------------------------------------------------------
+# Loader
+# --------------------------------------------------------------------------
+
+def test_load_wires_three_roles_with_correct_label_spaces():
+    m = _load_cascade()
+    assert set(m.members) == {"router", "coat", "viewpoint"}
+    assert len(m.members["router"].label_map) == 9
+    assert len(m.members["coat"].label_map) == 19
+    assert len(m.members["viewpoint"].label_map) == 20
+    # Each role is itself a 3-head ensemble.
+    for role in ("router", "coat", "viewpoint"):
+        assert len(m.members[role].models) == 3
+
+
+def test_load_enables_compound_labels_by_default():
+    m = _load_cascade()
+    for role in ("router", "coat", "viewpoint"):
+        assert m.members[role].compound_labels is True
+
+
+@pytest.mark.parametrize("missing", ["router", "coat", "viewpoint"])
+def test_load_missing_role_raises(missing):
+    with pytest.raises(ValueError, match="missing required role"):
+        _load_cascade(**{missing: None})
+
+
+def test_load_rejects_swapped_router_and_coat():
+    """v3 in the coat slot must fail loudly, not mislabel silently."""
+    with pytest.raises(ValueError, match="missing .* label"):
+        _load_cascade(
+            router=_role("v1", V1_COAT_CLASSES),
+            coat=_role("v3", V3_ROUTER_CLASSES),
+        )
+
+
+def test_load_rejects_swapped_router_and_viewpoint():
+    """The subtle one: v2 and v3 BOTH emit raw species 'wild_dog', so a
+    species-level check cannot catch this swap. Regression test for a real
+    defect — only v2 has wild_dog:front, only v3 has the triple_black tail."""
+    with pytest.raises(ValueError, match="missing .* label"):
+        _load_cascade(
+            router=_role("v2", V2_VIEWPOINT_CLASSES),
+            viewpoint=_role("v3", V3_ROUTER_CLASSES),
+        )
+
+
+def test_load_rejects_swapped_coat_and_viewpoint():
+    with pytest.raises(ValueError, match="missing .* label"):
+        _load_cascade(
+            coat=_role("v2", V2_VIEWPOINT_CLASSES),
+            viewpoint=_role("v1", V1_COAT_CLASSES),
+        )
+
+
+def test_load_rejects_unrelated_model_in_coat_slot():
+    cheetah = ["cheetah:left", "cheetah:right"]
+    mapping = dict(DEFAULT_MAPPING, cheetah=cheetah)
+    with pytest.raises(ValueError, match="missing .* label"):
+        _load_cascade(mapping=mapping, coat=_role("cheetah", cheetah))
+
+
+def _required_cases():
+    """Every individual required label, per role — dropping ANY must fail."""
+    from app.models.densenet_wilddog_cascade import REQUIRED_LABELS
+    real = {"router": V3_ROUTER_CLASSES, "coat": V1_COAT_CLASSES,
+            "viewpoint": V2_VIEWPOINT_CLASSES}
+    return [(role, real[role], label)
+            for role in ("router", "coat", "viewpoint")
+            for label in sorted(REQUIRED_LABELS[role][0])]
+
+
+@pytest.mark.parametrize("role,full,dropped", _required_cases())
+def test_load_rejects_role_missing_any_single_required_label(role, full, dropped):
+    """Exhaustive: a checkpoint missing even one required label is rejected.
+
+    A missing label wouldn't crash — the corresponding branch would just never
+    fire — so this is exactly the silent-degradation case load-time validation
+    exists to catch.
+    """
+    truncated = [c for c in full if c != dropped]
+    marker = f"trunc-{role}"
+    mapping = dict(DEFAULT_MAPPING, **{marker: truncated})
+    with pytest.raises(ValueError, match="missing .* label"):
+        _load_cascade(mapping=mapping, **{role: _role(marker, truncated)})
+
+
+@pytest.mark.parametrize("bad_label", [
+    "wild_dog_nocolon",   # no colon      -> species=None at inference
+    ":ignore",            # empty species
+    "wild_dog:",          # empty viewpoint
+    "wild_dog:a:b",       # two colons    -> viewpoint would become 'a:b'
+])
+def test_load_rejects_malformed_labels(bad_label):
+    bad = list(V3_ROUTER_CLASSES) + [bad_label]
+    mapping = dict(DEFAULT_MAPPING, v3bad=bad)
+    with pytest.raises(ValueError, match="non-compound label"):
+        _load_cascade(mapping=mapping, router=_role("v3bad", bad))
+
+
+def test_load_rejects_unknown_role_config_key():
+    spec = _role("v3", V3_ROUTER_CLASSES)
+    spec["chekpoint_paths"] = ["/typo"]
+    with pytest.raises(ValueError, match="unknown config key"):
+        _load_cascade(router=spec)
+
+
+def test_load_rejects_unknown_top_level_config_key():
+    with pytest.raises(ValueError, match="unknown config key"):
+        _load_cascade(imgsz=640)
+
+
+def test_failed_load_leaves_no_partial_members():
+    from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
+    m = DenseNetWildDogCascadeModel()
+    with patch("torch.load", side_effect=_torch_load_by_path(DEFAULT_MAPPING)), \
+         patch(_PATCH_CKPT, side_effect=lambda p: p):
+        with pytest.raises(ValueError):
+            m.load(model_id="wd", device="cpu",
+                   router=_role("v1", V1_COAT_CLASSES),   # wrong -> rejected
+                   coat=_role("v3", V3_ROUTER_CLASSES),
+                   viewpoint=_role("v2", V2_VIEWPOINT_CLASSES))
+    assert m.members == {}, "a rejected load must not leave members wired up"
+
+
+def test_failed_reload_does_not_corrupt_an_already_loaded_cascade():
+    """A failed reload must not pair the old members with the new metadata."""
+    m = _load_cascade()
+    good_members = m.members
+    with patch("torch.load", side_effect=_torch_load_by_path(DEFAULT_MAPPING)), \
+         patch(_PATCH_CKPT, side_effect=lambda p: p):
+        with pytest.raises(ValueError):
+            m.load(model_id="new-id", device="cpu", img_size=999,
+                   router=_role("v1", V1_COAT_CLASSES),   # wrong -> rejected
+                   coat=_role("v3", V3_ROUTER_CLASSES),
+                   viewpoint=_role("v2", V2_VIEWPOINT_CLASSES))
+    assert m.members is good_members, "members must be untouched"
+    assert m.model_id == "wd-cascade", "model_id must not adopt the failed load"
+    assert m.img_size == 224, "img_size must not adopt the failed load"
+
+
+# --------------------------------------------------------------------------
+# Decision table — core_annots.py:2200-2217
+# --------------------------------------------------------------------------
+
+class _StubMember:
+    """Stands in for a loaded DenseNetClassifierModel role."""
+
+    def __init__(self, species, viewpoint, probability):
+        self.label_map = {0: f"{species}:{viewpoint}"}
+        self.models = [None]
+        self._top = {
+            "label": f"{species}:{viewpoint}",
+            "probability": probability,
+            "index": 0,
+            "species": species,
+            "viewpoint": viewpoint,
+        }
+
+    def predict(self, image_bytes, bbox=None, theta=0.0, **kwargs):
+        return {"predictions": [self._top]}
+
+
+def _cascade_with(router, coat, viewpoint):
+    from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
+    m = DenseNetWildDogCascadeModel()
+    m.model_id = "wd-cascade"
+    m.members = {"router": _StubMember(*router),
+                 "coat": _StubMember(*coat),
+                 "viewpoint": _StubMember(*viewpoint)}
+    return m
+
+
+def test_body_all_three_agree_uses_coat_species_and_v2_viewpoint():
+    """The whole point of the cascade: coat from v1, viewpoint from v2."""
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_standard", "left", 0.8),
+        viewpoint=("wild_dog", "frontleft", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog_standard"
+    # 'frontleft' exists only in v2's label space, never in v1's.
+    assert out["predictions"][0]["viewpoint"] == "frontleft"
+    assert out["class"] == "wild_dog_standard:frontleft"
+
+
+def test_body_with_puppy_viewpoint_member_still_counts_as_body():
+    """v2's wild_dog_puppy is a body class too (flag2)."""
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_tan", "right", 0.8),
+        viewpoint=("wild_dog_puppy", "ignore", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog_tan"
+    assert out["predictions"][0]["viewpoint"] == "ignore"
+
+
+def test_body_with_puppy_coat_uses_puppy_species():
+    """v1's wild_dog_puppy is in the coat body set (flag1)."""
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_puppy", "ignore", 0.8),
+        viewpoint=("wild_dog", "backright", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog_puppy"
+    assert out["predictions"][0]["viewpoint"] == "backright"
+
+
+def test_body_but_coat_says_tail_is_ambiguous():
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog+tail_general", "ignore", 0.8),
+        viewpoint=("wild_dog", "left", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog_ambiguous"
+    assert out["predictions"][0]["viewpoint"] == "ambiguous"
+
+
+def test_body_but_viewpoint_says_tail_is_ambiguous():
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_dark", "left", 0.8),
+        viewpoint=("wild_dog+tail_standard", "ignore", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog_ambiguous"
+
+
+def test_tail_all_agree_uses_router_tail_class_and_ignore_viewpoint():
+    m = _cascade_with(
+        router=("wild_dog+tail_triple_black", "ignore", 0.9),
+        coat=("wild_dog+tail_general", "ignore", 0.8),
+        viewpoint=("wild_dog+tail_standard", "ignore", 0.7),
+    )
+    out = m.predict(b"img")
+    # v3 is the only model that knows tail_triple_black.
+    assert out["predictions"][0]["species"] == "wild_dog+tail_triple_black"
+    assert out["predictions"][0]["viewpoint"] == "ignore"
+
+
+def test_tail_but_coat_says_body_is_tail_ambiguous():
+    m = _cascade_with(
+        router=("wild_dog+tail_long_white", "ignore", 0.9),
+        coat=("wild_dog_standard", "left", 0.8),
+        viewpoint=("wild_dog+tail_general", "ignore", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog+tail_ambiguous"
+    assert out["predictions"][0]["viewpoint"] == "ambiguous"
+
+
+def test_tail_but_viewpoint_says_body_is_tail_ambiguous():
+    m = _cascade_with(
+        router=("wild_dog+tail_long_white", "ignore", 0.9),
+        coat=("wild_dog+tail_general", "ignore", 0.8),
+        viewpoint=("wild_dog", "front", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["species"] == "wild_dog+tail_ambiguous"
+
+
+# --------------------------------------------------------------------------
+# Score + output contract
+# --------------------------------------------------------------------------
+
+def test_score_is_mean_of_three_member_probabilities():
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_standard", "left", 0.6),
+        viewpoint=("wild_dog", "left", 0.3),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"][0]["probability"] == pytest.approx(0.6)
+    assert out["probability"] == pytest.approx(0.6)
+
+
+def test_output_matches_classify_slot_contract():
+    """pipeline_router reads predictions[0].{label,probability,index,species,viewpoint}."""
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_general", "other", 0.8),
+        viewpoint=("wild_dog", "upright", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["predictions"], "router requires a non-empty predictions list"
+    top = out["predictions"][0]
+    for key in ("label", "probability", "index", "species", "viewpoint"):
+        assert key in top, f"classify contract requires predictions[0].{key}"
+    assert top["label"] == "wild_dog_general:upright"
+
+
+def test_cascade_diagnostics_report_each_member():
+    m = _cascade_with(
+        router=("wild_dog", "ignore", 0.9),
+        coat=("wild_dog_general", "other", 0.8),
+        viewpoint=("wild_dog", "upright", 0.7),
+    )
+    out = m.predict(b"img")
+    assert out["cascade"]["router"]["species"] == "wild_dog"
+    assert out["cascade"]["coat"]["species"] == "wild_dog_general"
+    assert out["cascade"]["viewpoint"]["viewpoint"] == "upright"
+
+
+def test_ambiguous_classes_are_reachable_only_via_disagreement():
+    """No member has an 'ambiguous' class; it must come from the cascade."""
+    from app.models.densenet_wilddog_cascade import (
+        AMBIGUOUS_BODY, AMBIGUOUS_TAIL,
+    )
+    for classes in (V1_COAT_CLASSES, V2_VIEWPOINT_CLASSES, V3_ROUTER_CLASSES):
+        species = {c.split(":", 1)[0] for c in classes}
+        assert AMBIGUOUS_BODY not in species
+        assert AMBIGUOUS_TAIL not in species
+
+
+def test_registered_in_model_registry():
+    from app.models.model_handler import MODEL_REGISTRY
+    entry = MODEL_REGISTRY["densenet-wilddog-cascade"]
+    assert entry["class"] == "DenseNetWildDogCascadeModel"
+
+
+def test_not_confusable_with_plain_densenet_classifier():
+    """The cascade must be its own type: DenseNetClassifierModel's load()
+    contract (checkpoint_path/checkpoint_paths) is not the cascade's, so it
+    must not be substitutable for one."""
+    from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
+    from app.models.densenet_classifier import DenseNetClassifierModel
+    assert not isinstance(DenseNetWildDogCascadeModel(), DenseNetClassifierModel)


### PR DESCRIPTION
## Why

African Carnivore Wildbook (ACW) is migrating from WBIA to the ml-service. Nine of its ten species need config only — Whiskerbook's migration already covers leopard, lion, hyaena and the rest, and `densenet-classifier` handles their labelers today.

Wild dogs are the exception, and they need code.

WBIA labels wild dogs with **three** DenseNet models via a hardcoded special case for the exact tag string `wilddog_v3+wilddog_v2+wilddog_v1` ([`wbia/core_annots.py:2163`](https://github.com/WildMeOrg/wildbook-ia/blob/main/wbia/core_annots.py)). Every *other* multi-tag string hits `raise NotImplementedError('Muti-tier labeler config not supported')`, so wild dog is the only species that has ever used this.

**It is not an ensemble.** The three models play distinct roles and vote:

| Model | Role |
|---|---|
| **v3** | body-vs-tail **router** (the gate) + supplies the tail class |
| **v1** | supplies the body **coat** class |
| **v2** | supplies the body **viewpoint** |

The router gates; the other two must agree with it, or the annotation is labeled ambiguous.

## Why the existing densenet-classifier can't do this

`checkpoint_paths` does softmax-**averaging** and hard-requires identical `num_classes` **and** identical class order across members (`densenet_classifier.py:90-130`). The wild dog models have **19 / 20 / 9** classes. Loading them as one ensemble raises — and since `main.py` eager-loads every `model_config.json` entry and re-raises on any failure, that would crash the service for **every install sharing the box** (Whiskerbook, zebra, giraffespotter, salamander).

## Why the roles split this way

The label spaces make it obvious, and it's why "just pick one model" is wrong:

| Model | Classes | Contributes |
|---|---|---|
| v1 | 19 | coat classes, but only **3** viewpoints (`left`/`other`/`right`) |
| v2 | 20 | only plain `wild_dog`, but **14** viewpoints (`front`, `backleft`, `upright`, …) |
| v3 | 9 | the 8 tail classes + the `wild_dog:ignore` gate |

Viewpoint comes from v2 and coat from v1 **deliberately**. Collapsing to any single model would drop wild dog viewpoints from 14 values to 3 — and viewpoint scopes matching sets, so that degrades ID quality, not just metadata.

`wild_dog_ambiguous` / `wild_dog+tail_ambiguous` exist **only** as the cascade's disagreement output — no individual model has an "ambiguous" class — which is why ACW's IA.json declares them as iaClasses. ACW's live data confirms it: its annotation catalog contains `wild_dog_ambiguous` (1,905) and `wild_dog_standard+tail_ambiguous`, labels nothing but this cascade can produce.

## What this adds

- **`app/models/densenet_wilddog_cascade.py`** — new `densenet-wilddog-cascade` model type. Each role is itself a 3-head `DenseNetClassifierModel`, so all checkpoint loading, preprocessing and averaging is **reused**, not reimplemented. The cascade is a thin decision layer over existing machinery.
- **`app/models/model_handler.py`** — registry entry (+4 lines).
- **`app/routers/pipeline_router.py`** — import + the classify-slot `isinstance` tuple (+7/-2).
- **`tests/test_densenet_wilddog_cascade.py`** — 68 tests.

Additive only. No existing model type is touched; the 9-line change to existing code is the whole exposure to the shared service.

## Load-time validation

The v1/v2/v3 archives look alike on disk, and a swap would **silently mislabel every annotation** rather than error, so each role must expose the labels that distinguish its model *and* every label the decision table reads.

Checking raw *species* is not sufficient — **v2 and v3 both emit species `wild_dog`**, so a router/viewpoint swap passes a species-level check. (This was a real bug caught in review.) The discriminators are `wild_dog:front` (v2 only), `wild_dog+tail_triple_black:ignore` (v3 only), and the coat classes (v1 only).

Fail-fast at load is deliberate: eager-load already crashes on bad config, so a loud error beats silent mislabeling.

## Verification

- **Real ACW checkpoints**: all 9 densenet201 models load, `predict` returns the documented contract, and a genuine router/viewpoint swap is rejected.
- **68 tests**: all four decision-table branches, the `wild_dog_puppy` edge on both v1 and v2, every role swap, malformed labels, exhaustive per-label truncation (37 parametrized cases — dropping *any* single required label fails), config-typo rejection, and load atomicity.
- **Full suite: 110 passed** on this branch.
- Codex reviewed to convergence over 3 rounds ("The decision logic is an exact semantic port of `core_annots.py:2188-2233`… No remaining bug found at any severity").

## Deploying

Requires the wild dog labeler archives pre-extracted under `/datasets` (ml-service does not unzip), and a `model_config.json` entry:

```json
{
  "model_id": "wild_dog_v1v2v3-cascade",
  "model_type": "densenet-wilddog-cascade",
  "img_size": 224,
  "router":    {"checkpoint_paths": ["/datasets/labeler.wild_dog.v3/<inner>/labeler.{0,1,2}.weights"]},
  "coat":      {"checkpoint_paths": ["/datasets/labeler.wild_dog.v1/<inner>/labeler.{0,1,2}.weights"]},
  "viewpoint": {"checkpoint_paths": ["/datasets/labeler.wild_dog.v2/<inner>/labeler.{0,1,2}.weights"]}
}
```

Inner directory names must be preserved exactly — they encode the label set.

## Known gap (out of scope, tracked separately)

ACW's wild dog config also sets `assigner_algo: wd_v0`, which links detected tails to the right dog's body. `/pipeline/` does not run the assigner (it exists only in `/assign` and the WBIA-compat router), and Wildbook's `_mlservice_conf` has no key to request it.

Measured on ACW's live DB: **~30% of wild dog photos (17,661) would orphan their tails, affecting 57% of all tails (29,963)**. Matching is unaffected (tails carry `_id_conf: []`), and single-dog photos still group correctly via `MediaAsset.assignEncounters`. Closing it needs changes in both this repo and Wildbook, so it belongs in its own PR — filed as follow-up work, and it should land before ACW ingests wild dog uploads at volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
