### PR TITLE
fix: never fabricate orientation class labels (#33)

### DIFF
--- a/app/models/densenet_orientation.py
+++ b/app/models/densenet_orientation.py
@@ -6,6 +6,7 @@ import numpy as np
 from typing import Dict, Any, List, Optional, Tuple
 import logging
 from collections import OrderedDict
+from collections.abc import Mapping
 from torch import nn
 from albumentations.pytorch import ToTensorV2
 from albumentations import Compose, Resize, Normalize
@@ -14,7 +15,38 @@ from ..utils.checkpoint_utils import get_checkpoint_path
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ORIENTATION_CLASSES = ['down', 'front', 'left', 'right', 'up']
+# NOTE: there is deliberately no default class list here.
+#
+# A previous version fell back to ['down','front','left','right','up'] whenever a
+# checkpoint declared no classes and happened to have 5 outputs. That guess had no
+# basis in the model, and every checkpoint deployed under this type turned out to be
+# a wbia-plugin-orientation ORIENTED-BBOX REGRESSOR whose 5 outputs are the
+# coordinates [xc, yc, xt, yt, w] used to derive theta -- not class logits. Softmaxing
+# them produced near-uniform "probabilities" (~0.2 against a 1/5 baseline) and
+# effectively random viewpoints, which Wildbook then stored: its
+# Annotation.isValidViewpoint guard could not reject them because down/front/left/
+# right/up are all legitimate viewpoints. Whale-shark matching filters candidates on
+# viewpoint, so this sent queries at the wrong flank. See issue #33.
+#
+# A label map must now come from the checkpoint's 'classes' or an explicit config
+# label_map. Real classifiers in this ecosystem carry 'classes'; the regressors do
+# not -- so requiring them is also what distinguishes the two, since num_classes==5
+# matches a 5-class classifier and a 5-coordinate regressor identically.
+
+
+def _validated_labels(label_map: dict, model_id: str) -> dict:
+    """Every resolved label must be a non-empty string.
+
+    A non-string label would be emitted verbatim as a prediction and, for
+    viewpoints, silently fail Wildbook's isValidViewpoint check downstream.
+    """
+    for idx, label in sorted(label_map.items()):
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError(
+                f"Orientation model '{model_id}': label for index {idx} must be a "
+                f"non-empty string; got {label!r}."
+            )
+    return label_map
 
 
 def _detect_architecture(state_dict: dict) -> str:
@@ -43,7 +75,8 @@ class DenseNetOrientationModel(BaseModel):
 
     Compatible with WBIA orientation model checkpoints in two formats:
     - Wrapped: {'state': state_dict, 'classes': class_list}
-    - Raw: bare state_dict (classes must come from config or defaults)
+    - Raw: bare state_dict (classes MUST then come from an explicit config
+      label_map; they are never guessed -- see issue #33)
     """
 
     def __init__(self):
@@ -105,17 +138,66 @@ class DenseNetOrientationModel(BaseModel):
             else:
                 raise ValueError(f"Cannot determine num_classes: '{classifier_key}' not found in checkpoint")
 
-            # Determine label map: config > checkpoint > default
+            # Determine label map: config > checkpoint. Never guessed -- see the
+            # note at the top of this module and issue #33.
             if label_map is not None:
-                self.label_map = {int(k): v for k, v in label_map.items()}
+                if not isinstance(label_map, Mapping):
+                    raise ValueError(
+                        f"Orientation model '{model_id}': label_map must be a mapping "
+                        f"of index -> label; got {type(label_map).__name__}."
+                    )
+                coerced = {}
+                for k, v in label_map.items():
+                    try:
+                        ik = int(k)
+                    except (TypeError, ValueError):
+                        raise ValueError(
+                            f"Orientation model '{model_id}': label_map key {k!r} is "
+                            f"not an integer index."
+                        )
+                    # JSON allows "0" and "00" as distinct keys; both coerce to 0
+                    # and one would silently overwrite the other.
+                    if ik in coerced:
+                        raise ValueError(
+                            f"Orientation model '{model_id}': label_map has duplicate "
+                            f"index {ik} after integer coercion (e.g. \"0\" and \"00\")."
+                        )
+                    coerced[ik] = v
+                expected = set(range(num_classes))
+                if set(coerced.keys()) != expected:
+                    raise ValueError(
+                        f"Orientation model '{model_id}': config label_map keys must be "
+                        f"exactly {sorted(expected)}; got {sorted(coerced.keys())}."
+                    )
+                self.label_map = _validated_labels(coerced, model_id)
             elif classes is not None:
-                self.label_map = {i: c for i, c in enumerate(classes)}
-            elif num_classes == len(DEFAULT_ORIENTATION_CLASSES):
-                self.label_map = {i: c for i, c in enumerate(DEFAULT_ORIENTATION_CLASSES)}
-                logger.info(f"Using default orientation classes: {DEFAULT_ORIENTATION_CLASSES}")
+                # A bare string is iterable: enumerate("abc") would silently yield
+                # 'a','b','c' for a 3-output head. Require a real sequence.
+                if isinstance(classes, str) or not isinstance(classes, (list, tuple)):
+                    raise ValueError(
+                        f"Orientation model '{model_id}': checkpoint 'classes' must be "
+                        f"a list or tuple of labels; got {type(classes).__name__}."
+                    )
+                if len(classes) != num_classes:
+                    raise ValueError(
+                        f"Orientation model '{model_id}': checkpoint 'classes' has "
+                        f"{len(classes)} entries but the classifier head has "
+                        f"num_classes={num_classes} -- stale metadata."
+                    )
+                self.label_map = _validated_labels(
+                    {i: c for i, c in enumerate(classes)}, model_id)
             else:
-                self.label_map = {i: f"class_{i}" for i in range(num_classes)}
-                logger.warning(f"No class labels found, using generic labels for {num_classes} classes")
+                raise ValueError(
+                    f"Orientation model '{model_id}': checkpoint declares no 'classes' "
+                    f"and no label_map was configured, so the meaning of its "
+                    f"{num_classes} outputs is unknown. This model type will NOT guess "
+                    f"-- guessed labels are indistinguishable from real predictions "
+                    f"downstream (issue #33). Either add an explicit label_map to this "
+                    f"model's model_config.json entry, or remove the entry: a "
+                    f"wbia-plugin-orientation checkpoint is an oriented-bbox regressor "
+                    f"(outputs [xc, yc, xt, yt, w] for deriving theta), not a "
+                    f"classifier, and no label_map can make it one."
+                )
 
             # Create model based on detected architecture
             if self.architecture == 'hrnet_w32':

--- a/tests/test_densenet_orientation_labels.py
+++ b/tests/test_densenet_orientation_labels.py
@@ -1,0 +1,196 @@
+"""Label-resolution tests for DenseNetOrientationModel.
+
+Regression cover for issue #33: the loader used to invent a class list
+(['down','front','left','right','up']) whenever a checkpoint declared no classes
+and happened to have 5 outputs. Every checkpoint deployed under this type was in
+fact a wbia-plugin-orientation oriented-bbox REGRESSOR whose 5 outputs are
+[xc, yc, xt, yt, w] -- coordinates for deriving theta, not class logits. The
+fabricated labels were indistinguishable from real predictions downstream and
+Wildbook stored them as viewpoints.
+
+We mock torch.load rather than ship real HRNet/DenseNet weights.
+"""
+from collections import OrderedDict
+from unittest.mock import patch
+
+import pytest
+import torch
+
+_PATCH_CKPT = "app.models.densenet_orientation.get_checkpoint_path"
+
+
+def _state(num_classes: int, hrnet: bool = True) -> OrderedDict:
+    """Synthetic state dict; classifier feature dim implies the architecture
+    (2048 -> hrnet_w32, 1920 -> densenet201) via _detect_architecture."""
+    feat = 2048 if hrnet else 1920
+    st = OrderedDict()
+    st["classifier.weight"] = torch.zeros(num_classes, feat)
+    st["classifier.bias"] = torch.zeros(num_classes)
+    return st
+
+
+def _wrapped(num_classes, classes, hrnet=True):
+    return {"state": _state(num_classes, hrnet), "classes": classes}
+
+
+def _raw(num_classes, hrnet=True):
+    """A bare state_dict — exactly the shape of orientation.whaleshark.v3.pth."""
+    return _state(num_classes, hrnet)
+
+
+class _StubBackbone(torch.nn.Module):
+    """Minimal real Module whose state_dict keys are exactly
+    classifier.{weight,bias} — matching the synthetic checkpoints above, so
+    load_state_dict() succeeds at its default strict=True. It must be a real
+    nn.Module (not a MagicMock) because load() wraps .classifier in an
+    nn.Sequential with a Softmax."""
+
+    def __init__(self, feat: int, num_classes: int):
+        super().__init__()
+        self.classifier = torch.nn.Linear(feat, num_classes)
+
+
+def _load(checkpoint, **kwargs):
+    """Load with the backbone stubbed; these tests pin label resolution only."""
+    from app.models.densenet_orientation import DenseNetOrientationModel
+
+    def _timm(*_a, **kw):
+        return _StubBackbone(2048, kw.get("num_classes", 5))
+
+    with patch("torch.load", return_value=checkpoint), \
+         patch(_PATCH_CKPT, side_effect=lambda p: p), \
+         patch("timm.create_model", side_effect=_timm):
+        m = DenseNetOrientationModel()
+        m.load(model_id=kwargs.pop("model_id", "t"),
+               checkpoint_path="/fake/ckpt.pth", device="cpu", **kwargs)
+    return m
+
+
+# --------------------------------------------------------------------------
+# The regression: never fabricate labels
+# --------------------------------------------------------------------------
+
+def test_raw_checkpoint_with_5_outputs_is_rejected_not_guessed():
+    """Issue #33: this is the whaleshark_v3 / leopard_shark_v0-orient shape.
+
+    5 outputs + no classes used to silently become ['down','front','left',
+    'right','up']. Those are all VALID Wildbook viewpoints, so nothing
+    downstream could reject them.
+    """
+    with pytest.raises(ValueError, match="declares no 'classes'"):
+        _load(_raw(5), model_id="whaleshark_v3")
+
+
+def test_rejection_message_is_actionable():
+    with pytest.raises(ValueError) as e:
+        _load(_raw(5), model_id="whaleshark_v3")
+    msg = str(e.value)
+    assert "whaleshark_v3" in msg, "must name the offending model"
+    assert "label_map" in msg, "must say how to fix it"
+    assert "regressor" in msg, "must explain why a label_map may not be the answer"
+
+
+@pytest.mark.parametrize("n", [2, 3, 4, 5, 6, 8])
+def test_no_output_count_is_ever_guessed(n):
+    """The old code guessed at n==5 and emitted 'class_i' otherwise. Neither
+    is acceptable: both fabricate meaning the checkpoint never carried."""
+    with pytest.raises(ValueError, match="declares no 'classes'"):
+        _load(_raw(n))
+
+
+def test_generic_class_i_labels_are_not_emitted_either():
+    with pytest.raises(ValueError):
+        _load(_raw(7))
+
+
+def test_default_orientation_classes_constant_is_gone():
+    """Guard against the guess being reintroduced."""
+    import app.models.densenet_orientation as mod
+    assert not hasattr(mod, "DEFAULT_ORIENTATION_CLASSES"), \
+        "the fabricated default class list must not come back (issue #33)"
+
+
+# --------------------------------------------------------------------------
+# Legitimate paths still work
+# --------------------------------------------------------------------------
+
+def test_checkpoint_classes_are_used():
+    m = _load(_wrapped(3, ["left", "right", "back"]))
+    assert m.label_map == {0: "left", 1: "right", 2: "back"}
+
+
+def test_config_label_map_is_used():
+    m = _load(_raw(3), label_map={0: "left", 1: "right", 2: "back"})
+    assert m.label_map == {0: "left", 1: "right", 2: "back"}
+
+
+def test_config_label_map_wins_over_checkpoint_classes():
+    m = _load(_wrapped(2, ["a", "b"]), label_map={0: "left", 1: "right"})
+    assert m.label_map == {0: "left", 1: "right"}
+
+
+def test_config_label_map_accepts_string_keys():
+    """model_config.json is JSON, so keys arrive as strings."""
+    m = _load(_raw(2), label_map={"0": "left", "1": "right"})
+    assert m.label_map == {0: "left", 1: "right"}
+
+
+# --------------------------------------------------------------------------
+# Stale / malformed metadata
+# --------------------------------------------------------------------------
+
+def test_checkpoint_classes_length_mismatch_raises():
+    with pytest.raises(ValueError, match="stale metadata"):
+        _load(_wrapped(5, ["left", "right"]))
+
+
+def test_config_label_map_wrong_keys_raises():
+    with pytest.raises(ValueError, match="label_map keys must be exactly"):
+        _load(_raw(3), label_map={0: "left", 1: "right", 5: "back"})
+
+
+def test_config_label_map_too_short_raises():
+    with pytest.raises(ValueError, match="label_map keys must be exactly"):
+        _load(_raw(3), label_map={0: "left", 1: "right"})
+
+
+# --------------------------------------------------------------------------
+# Metadata validation hardening (Codex review, round 1)
+# --------------------------------------------------------------------------
+
+def test_checkpoint_classes_as_bare_string_is_rejected():
+    """enumerate("abc") would silently yield 'a','b','c' for a 3-output head."""
+    with pytest.raises(ValueError, match="must be a list or tuple"):
+        _load({"state": _state(3), "classes": "abc"})
+
+
+def test_checkpoint_classes_wrong_type_is_rejected():
+    with pytest.raises(ValueError, match="must be a list or tuple"):
+        _load({"state": _state(2), "classes": {"0": "left", "1": "right"}})
+
+
+def test_label_map_not_a_mapping_is_rejected():
+    with pytest.raises(ValueError, match="must be a mapping"):
+        _load(_raw(2), label_map=["left", "right"])
+
+
+def test_label_map_duplicate_keys_after_coercion_are_rejected():
+    """JSON permits "0" and "00" as distinct keys; both coerce to 0."""
+    with pytest.raises(ValueError, match="duplicate index"):
+        _load(_raw(2), label_map={"0": "left", "00": "other", "1": "right"})
+
+
+def test_label_map_non_integer_key_is_rejected():
+    with pytest.raises(ValueError, match="not an integer index"):
+        _load(_raw(2), label_map={"left": "left", "1": "right"})
+
+
+@pytest.mark.parametrize("bad", [None, 5, "", "   ", ["left"]])
+def test_non_string_or_empty_labels_are_rejected(bad):
+    with pytest.raises(ValueError, match="non-empty string"):
+        _load(_raw(2), label_map={0: bad, 1: "right"})
+
+
+def test_checkpoint_classes_with_non_string_entry_is_rejected():
+    with pytest.raises(ValueError, match="non-empty string"):
+        _load({"state": _state(2), "classes": ["left", None]})


### PR DESCRIPTION
Fixes #33.

## The bug

`densenet-orientation` invented class names when a checkpoint didn't supply them, then emitted them as authoritative predictions:

```python
elif num_classes == len(DEFAULT_ORIENTATION_CLASSES):
    self.label_map = {i: c for i, c in enumerate(DEFAULT_ORIENTATION_CLASSES)}
```

Every checkpoint deployed under this type is a **`wbia-plugin-orientation` oriented-bbox regressor**. Its 5 outputs are the coordinates `[xc, yc, xt, yt, w]` used to derive theta ([`evaluate.py:13`](https://github.com/WildMeOrg/wbia-plugin-orientation)), **not class logits**. Softmaxing them gave near-uniform "probabilities" and effectively random viewpoints:

```
whaleshark.jpg -> {"label": "down", "probability": 0.2575}   # 1/5 baseline = 0.20
ws2.jpg        -> {"label": "left", "probability": 0.2954}
```

Reported symptom: **Sharkbook whale shark viewpoints "unusually wrong."** Whale shark matching filters candidates on viewpoint and spot patterns are side-specific, so a wrong `left`/`right` sends the query at the wrong flank → missed matches.

**Why nothing caught it.** `num_classes == 5` matches a 5-class classifier *and* a 5-coordinate regressor identically. And Wildbook's `Annotation.isValidViewpoint` guard — written to reject "a stray orientation label" — can't help, because `down/front/left/right/up` are all legitimate viewpoints. The guess was plausible enough to defeat the check written to catch it.

## The fix

A label map must come from the checkpoint's `classes` or an explicit config `label_map`; otherwise `load()` raises with an actionable message. No path fabricates a label.

Real classifiers in this ecosystem carry `classes`; the regressors don't — so requiring them is also what distinguishes the two. An explicit `label_map` can still mislabel a regressor, but that's a deliberate operator assertion rather than something inferred from an output count.

Validation tightened alongside (from review):
- `label_map` must be a mapping, keys exactly `range(num_classes)`, **no duplicates after integer coercion** (JSON permits `"0"` and `"00"`)
- checkpoint `classes` must be a list/tuple, **not a bare string** — `enumerate("abc")` would silently yield `a`, `b`, `c`
- every resolved label must be a non-empty string

## Verification

- **Against the real `orientation.whaleshark.v3.pth`**: previously loaded and emitted viewpoints; now rejected with the actionable message.
- 28 new tests: every output count rejected when classes are absent (incl. 5), legitimate checkpoint/config paths, stale metadata, and each validation gap above. A guard test fails if `DEFAULT_ORIENTATION_CLASSES` is ever reintroduced.
- **Full suite: 138 passed.**
- Codex-reviewed; both findings addressed.

## ⚠️ DEPLOYMENT — coordinated config migration, NOT a drop-in

All three deployed `densenet-orientation` entries declare no classes (verified live — identical guessed label maps), so **after this change they fail to load until removed**. `main.py` eager-loads every entry and re-raises, so a stale config takes down every install on the box.

| model_id | status |
|---|---|
| `whaleshark_v3` | regressor — remove |
| `leopard_shark_v0-orient` | regressor — remove |
| `orientation-fire-salamander` | regressor — remove (bare `OrderedDict`, no `classes`, `(5, 2048)`) |

**Order matters.** `pipeline_router.py:114` returns **404** if `orientation_model_id` names a missing model — so removing the entries first would break Sharkbook detection entirely, which is worse than the bug:

1. **First**: drop `orientation_model_id` from consuming IA.json configs (Sharkbook `Rhincodon.typus`, and any install using `leopard_shark_v0-orient` / `orientation-fire-salamander`).
2. **Then, together**: remove the three entries from `model_config.json` **and** deploy this code.
3. Restart; confirm `/health` reports the expected `models_loaded` and smoke-test one detection per affected install.

Viewpoints for those species become null rather than wrong. Null is a strictly better input to a viewpoint filter than a random value.

## Follow-ups (not this PR)

- `msv2_multilabel_flip_effnet_v0` (whale shark's classifier) omits `parse_compound_labels`, which defaults to `False`, so species/viewpoint are never populated — that's what makes Wildbook fall back to the orientation label at all. Setting it `true` would give whale sharks real viewpoints from an actual viewpoint classifier. Behaviour change; deserves its own PR and test.
- These checkpoints are still useful **as intended**: a distinct model type could derive theta from `[xc, yc, xt, yt, w]` rather than discarding them.

Found while smoke-testing an unrelated ACW migration; not caused by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
