### PR TITLE
feat: restore whale shark rotation — wbia-orientation theta model type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 ## ds
 .DS_Store
 Thumbs.db
+
+# preflight gate output — recorded per host run, not source
+preflight-artifact.json

--- a/app/models/model_handler.py
+++ b/app/models/model_handler.py
@@ -35,6 +35,10 @@ MODEL_REGISTRY = {
         'module': 'app.models.densenet_wilddog_cascade',
         'class': 'DenseNetWildDogCascadeModel'
     },
+    'wbia-orientation': {
+        'module': 'app.models.wbia_orientation',
+        'class': 'WbiaOrientationModel'
+    },
     'lightnet': {
         'module': 'app.models.lightnet_model',
         'class': 'LightNetModel'

--- a/app/models/wbia_orientation.py
+++ b/app/models/wbia_orientation.py
@@ -1,0 +1,315 @@
+"""wbia-plugin-orientation checkpoints run as the regressors they are.
+
+These checkpoints (orientation.whaleshark.v3, orientation.leopard_shark.v0,
+orientation.salamander_fire_adult.v2) are ORIENTED-BOUNDING-BOX REGRESSORS. Their
+5 outputs are `[xc, yc, xt, yt, w]`, normalized to [0,1] by a sigmoid head, and
+exist to derive **theta** -- the crop's angle of rotation. They are NOT
+classifiers.
+
+ml-service previously loaded them under `densenet-orientation`, which softmaxed
+those coordinates into fabricated viewpoint labels (issue #33) and never produced
+theta at all. Sharkbook whale sharks consequently lost rotation entirely in June
+2026: theta went from ~2-4% zero to 98% zero, so MiewID embedded tilted animals.
+This model type restores what WBIA actually did.
+
+Design: docs/plans/2026-07-16-wbia-orientation-theta-design.md
+Reference: wbia-plugin-orientation --
+  _plugin.py:189-296 (inference), dataset/animal_wbia.py:17-37 (preprocess),
+  models/orientation_net.py:63-95 (sigmoid head + TTA),
+  utils/utils.py:88-116 (un-flip), core/evaluate.py:9-20 (theta).
+
+Fidelity is load-bearing: this port's failure mode is being SILENTLY wrong by an
+angle, which is indistinguishable from correct output downstream. Every
+preprocessing choice below mirrors the reference exactly, and the host preflight
+compares this implementation against the reference live.
+"""
+import io
+import logging
+import math
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Sequence
+
+import imageio.v2 as imageio
+import numpy as np
+import timm
+import torch
+from skimage.transform import resize as sk_resize
+from torchvision import transforms
+
+from app.models.base_model import BaseModel
+from app.utils.checkpoint_utils import get_checkpoint_path
+
+logger = logging.getLogger(__name__)
+
+# wbia_orientation/config/default.py:41 -- MODEL.IMSIZE. No species YAML overrides
+# it (verified across wbia_orientation/config/*.yaml).
+DEFAULT_IMSIZE = (224, 224)
+
+# The head emits exactly [xc, yc, xt, yt, w].
+NUM_OUTPUTS = 5
+
+# dataset/animal_wbia.py:35 -- ImageNet statistics.
+_TRANSFORM = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+])
+
+
+class OrientationInferenceError(RuntimeError):
+    """Orientation could not produce a trustworthy theta.
+
+    Raised rather than returning a default: a fallback theta of 0.0 is exactly
+    the failure this model type exists to repair, and 0.0 is also a *valid*
+    prediction, so a sentinel cannot be distinguished from a real answer. The
+    router must fail the request rather than embed an unrotated crop.
+    """
+
+
+def _canonicalize_rgb(image: np.ndarray) -> np.ndarray:
+    """Coerce a decoded image to (H, W, 3).
+
+    DELIBERATE DEVIATION from the reference, documented in the design. The
+    reference feeds imageio's output straight into a 3-channel Normalize, so it
+    raises on grayscale (H,W) and RGBA (H,W,4) -- it has no behaviour to port
+    there, and an exception is not a specification. Failing a whole detection
+    because a frame is grayscale (routine for IR/night capture) is worse than
+    handling it. The preflight validates this wrapper by converting fixtures to
+    RGB externally and requiring the reference to agree with us.
+    """
+    if image.ndim == 2:                      # grayscale -> replicate
+        return np.stack([image] * 3, axis=-1)
+    if image.ndim == 3:
+        if image.shape[2] == 3:
+            return image                     # already reference-shaped: untouched
+        if image.shape[2] == 4:              # RGBA -> drop alpha
+            return image[:, :, :3]
+        if image.shape[2] == 1:
+            return np.repeat(image, 3, axis=2)
+    raise OrientationInferenceError(
+        f"Unsupported image shape {image.shape}; expected 2-D grayscale or "
+        f"(H, W, {{1,3,4}})."
+    )
+
+
+def resolve_bbox(bbox: Sequence[float], width: int, height: int) -> List[int]:
+    """Resolve a detector bbox to the slice the reference would ACTUALLY take.
+
+    The reference crops with raw NumPy slicing (`image[y1:y1+h, x1:x1+w]`), which
+    does NOT clamp: a negative origin resolves from the FAR EDGE. Measured on a
+    400px-wide image:
+
+        x1=-20, w=50   -> width 0   (empty)
+        x1=-20, w=500  -> width 20  taken from the image's RIGHT edge
+        x1=380, w=50   -> width 20  (silently truncated)
+
+    So an out-of-image bbox does not fail; it silently describes a region the
+    detector never pointed at. `slice(start, stop).indices(dim)` reproduces
+    exactly what NumPy did, and the resolved slice becomes `effective_bbox` --
+    which classify, extract, and the persisted result must all share, or theta
+    ends up describing a different region than the crop it rotates.
+
+    Returns [x, y, w, h] of the real in-bounds slice; w/h may be 0, which the
+    caller treats as the reference's empty-crop fallback.
+    """
+    if len(bbox) != 4:
+        raise OrientationInferenceError(
+            f"bbox must be [x, y, w, h]; got {len(bbox)} value(s)."
+        )
+    for v in bbox:
+        if v is None or not isinstance(v, (int, float)) or not math.isfinite(float(v)):
+            raise OrientationInferenceError(
+                f"bbox contains a non-finite or non-numeric value: {bbox!r}"
+            )
+
+    # Integerize ONCE, truncate-toward-zero, matching pipeline_router.py:218
+    # (`[int(x), int(y), int(width), int(height)]`). The rule matters: int(-0.5)
+    # is 0 but floor(-0.5) is -1, and -1 resolves from the far edge.
+    x, y, w, h = (int(v) for v in bbox)
+
+    x_start, x_stop, _ = slice(x, x + w).indices(width)
+    y_start, y_stop, _ = slice(y, y + h).indices(height)
+    return [x_start, y_start, max(0, x_stop - x_start), max(0, y_stop - y_start)]
+
+
+def compute_theta(coords: Sequence[float]) -> float:
+    """theta from normalized [xc, yc, xt, yt, w]. Mirrors core/evaluate.py:9-20.
+
+    arctan2(yt - yc, xt - xc), plus 90 degrees to align arctan2's notation with
+    the annotation convention. Computed on NORMALIZED coords, before any resize
+    back to image space -- orientation_post_proc calls compute_theta first.
+    """
+    theta = math.atan2(coords[3] - coords[1], coords[2] - coords[0])
+    return theta + math.radians(90)
+
+
+class WbiaOrientationModel(BaseModel):
+    """HRNet-W32 oriented-bbox regressor returning theta."""
+
+    def __init__(self):
+        super().__init__()
+        self.model = None
+        self.model_id: str = ""
+        self.device: str = "cpu"
+        self.imsize = DEFAULT_IMSIZE
+        self.hflip: bool = True
+        self.vflip: bool = True
+
+    def load(self, model_path: str = "", device: str = "cpu", model_id: str = "",
+             checkpoint_path: Optional[str] = None,
+             imsize: Optional[Sequence[int]] = None,
+             hflip: bool = True, vflip: bool = True,
+             **kwargs) -> None:
+        if kwargs:
+            raise ValueError(
+                f"wbia-orientation '{model_id}': unknown config key(s) "
+                f"{sorted(kwargs)}. Expected: checkpoint_path, imsize, hflip, vflip."
+            )
+        if not checkpoint_path:
+            raise ValueError(
+                f"wbia-orientation '{model_id}': checkpoint_path is required."
+            )
+        self.model_id = model_id
+        self.device = device
+        self.imsize = tuple(imsize) if imsize else DEFAULT_IMSIZE
+        # TEST.HFLIP / TEST.VFLIP default True in config/default.py:117-118 and no
+        # species YAML overrides them. Configurable, but on by default to match.
+        self.hflip, self.vflip = bool(hflip), bool(vflip)
+
+        actual = get_checkpoint_path(checkpoint_path)
+        raw = torch.load(actual, map_location=device, weights_only=False)
+        state = raw.get("state", raw) if isinstance(raw, dict) and "state" in raw else raw
+        clean = OrderedDict(
+            (k.replace("module.", "").replace("model.", ""), v) for k, v in state.items()
+        )
+
+        # timm's hrnet_w32 is equivalent to the reference's cls_hrnet: measured
+        # bit-identical (worst 5.96e-08 = 1 ULP of float32) across all 3
+        # checkpoints x 6 inputs. Re-checked by the host preflight; vendor
+        # cls_hrnet if that ever regresses. strict=True so a mismatched
+        # checkpoint fails loudly here rather than silently mispredicting.
+        model = timm.create_model("hrnet_w32", pretrained=False,
+                                  num_classes=NUM_OUTPUTS)
+        model.load_state_dict(clean, strict=True)
+        model.to(device).eval()
+        self.model = model
+
+        logger.info(
+            f"Loaded WbiaOrientationModel '{model_id}': imsize={self.imsize}, "
+            f"hflip={self.hflip}, vflip={self.vflip}"
+        )
+
+    # -- inference ---------------------------------------------------------
+
+    def _preprocess(self, image: np.ndarray, eff: List[int]) -> torch.Tensor:
+        crop = image[eff[1]:eff[1] + eff[3], eff[0]:eff[0] + eff[2]]
+        # dataset/animal_wbia.py:25-28 -- a degenerate crop falls back to the FULL
+        # image. The caller has already rewritten effective_bbox to match, so
+        # theta and the crop describe the same region.
+        if min(crop.shape[:2]) < 1:
+            crop = image
+        # skimage bicubic + anti-alias. NOT interchangeable with cv2.INTER_CUBIC:
+        # skimage applies a Gaussian prefilter when downscaling, and crops here
+        # routinely exceed 224. For a model whose output IS an angle, a resize
+        # mismatch is angular error (cf. miewid.py's ~3-degree drift note).
+        resized = sk_resize(crop, self.imsize, order=3, anti_aliasing=True)
+        # sk_resize returns float64 in [0,1], so ToTensor does NOT rescale by 255.
+        # float32 cast mirrors _plugin.py:272's `model(images.float(), ...)`.
+        return _TRANSFORM(resized).unsqueeze(0).float()
+
+    def _forward_tta(self, x: torch.Tensor) -> torch.Tensor:
+        """sigmoid head + hflip/vflip TTA. Mirrors orientation_net.py:63-95."""
+        with torch.no_grad():
+            out = torch.sigmoid(self.model(x))
+            if not (self.hflip or self.vflip):
+                return out
+            acc, n = out.clone(), 1
+            if self.hflip:
+                oh = torch.sigmoid(self.model(torch.flip(x, [3])))
+                # utils.py:88-102 with image_h_w=[1.0,1.0]: x-coords mirror, the
+                # rest are unchanged.
+                oh[:, 0] = 1.0 - oh[:, 0]
+                oh[:, 2] = 1.0 - oh[:, 2]
+                acc, n = acc + oh, n + 1
+            if self.vflip:
+                ov = torch.sigmoid(self.model(torch.flip(x, [2])))
+                # utils.py:104-116 -- y-coords mirror.
+                ov[:, 1] = 1.0 - ov[:, 1]
+                ov[:, 3] = 1.0 - ov[:, 3]
+                acc, n = acc + ov, n + 1
+            return acc / n
+
+    def predict(self, image_bytes: bytes,
+                bbox: Optional[Sequence[float]] = None,
+                theta: float = 0.0,
+                **kwargs) -> Dict[str, Any]:
+        # The reference regressor consumes the AXIS-ALIGNED bbox and infers the
+        # rotation itself. Handing it a crop that a detector already rotated would
+        # double-rotate. Harmless for lightnet (always 0.0) but wrong for an OBB
+        # detector, so reject it rather than silently accept.
+        if theta:
+            raise OrientationInferenceError(
+                f"wbia-orientation '{self.model_id}' takes an axis-aligned bbox and "
+                f"derives theta itself; it must not be given a pre-rotated crop "
+                f"(got theta={theta})."
+            )
+        return self.predict_batch(image_bytes, [bbox] if bbox is not None else [None])[0]
+
+    def predict_batch(self, image_bytes: bytes,
+                      bboxes: Sequence[Optional[Sequence[float]]]) -> List[Dict[str, Any]]:
+        """Exactly one ordered result per input bbox, or atomic failure.
+
+        Ordering is load-bearing: a misaligned result would attach one bbox's
+        theta to another bbox's crop. Callers must assert
+        len(results) == len(bboxes) before running any consumer.
+        """
+        if self.model is None:
+            raise OrientationInferenceError(
+                f"wbia-orientation '{self.model_id}': model is not loaded."
+            )
+        try:
+            decoded = imageio.imread(io.BytesIO(image_bytes))
+        except Exception as e:
+            raise OrientationInferenceError(f"could not decode image: {e}") from e
+        image = _canonicalize_rgb(np.asarray(decoded))
+        height, width = image.shape[:2]
+
+        results: List[Dict[str, Any]] = []
+        for bbox in bboxes:
+            src = [0, 0, width, height] if bbox is None else list(bbox)
+            eff = resolve_bbox(src, width, height)
+            if min(eff[2], eff[3]) < 1:
+                eff = [0, 0, width, height]   # reference full-frame fallback
+
+            x = self._preprocess(image, eff).to(self.device)
+            coords = self._forward_tta(x)[0].tolist()
+            th = compute_theta(coords)
+            if not math.isfinite(th):
+                # Fail rather than default: 0.0 is a legitimate prediction, so a
+                # sentinel would be indistinguishable from a real answer.
+                raise OrientationInferenceError(
+                    f"wbia-orientation '{self.model_id}': non-finite theta from "
+                    f"coords={coords}"
+                )
+            results.append({
+                "model_id": self.model_id,
+                "theta": float(th),
+                "coords_normalized": [float(c) for c in coords],
+                "effective_bbox": eff,
+            })
+        if len(results) != len(bboxes):   # defensive: the contract is ordered 1:1
+            raise OrientationInferenceError(
+                f"wbia-orientation '{self.model_id}': produced {len(results)} "
+                f"result(s) for {len(bboxes)} bbox(es)."
+            )
+        return results
+
+    def get_model_info(self) -> Dict[str, Any]:
+        return {
+            "model_type": "wbia-orientation",
+            "device": str(self.device),
+            "imsize": list(self.imsize),
+            "num_outputs": NUM_OUTPUTS,
+            "hflip": self.hflip,
+            "vflip": self.vflip,
+            "outputs": "theta (radians) + normalized [xc, yc, xt, yt, w]",
+        }

--- a/app/models/wbia_orientation.py
+++ b/app/models/wbia_orientation.py
@@ -26,6 +26,7 @@ compares this implementation against the reference live.
 import io
 import logging
 import math
+import numbers
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -116,7 +117,11 @@ def resolve_bbox(bbox: Sequence[float], width: int, height: int) -> List[int]:
             f"bbox must be [x, y, w, h]; got {len(bbox)} value(s)."
         )
     for v in bbox:
-        if v is None or not isinstance(v, (int, float)) or not math.isfinite(float(v)):
+        # numbers.Real, not (int, float): detectors hand us np.float32/np.int64,
+        # which are Real but NOT instances of the builtins. bool is excluded --
+        # it is an int subclass and a bbox coordinate of True is a bug, not a 1.
+        if isinstance(v, bool) or not isinstance(v, numbers.Real) \
+                or not math.isfinite(float(v)):
             raise OrientationInferenceError(
                 f"bbox contains a non-finite or non-numeric value: {bbox!r}"
             )
@@ -129,6 +134,27 @@ def resolve_bbox(bbox: Sequence[float], width: int, height: int) -> List[int]:
     x_start, x_stop, _ = slice(x, x + w).indices(width)
     y_start, y_stop, _ = slice(y, y + h).indices(height)
     return [x_start, y_start, max(0, x_stop - x_start), max(0, y_stop - y_start)]
+
+
+def _validate_coords(coords: Sequence[float], model_id: str) -> None:
+    """All five outputs must be finite before theta is derived.
+
+    Checking only the derived theta is insufficient: theta reads indices 0-3, so
+    a NaN in `w` (index 4) yields a *finite* theta and would be emitted inside
+    coords_normalized. Any non-finite output means the model result is malformed
+    and the request must fail (design: malformed/non-finite -> fail-closed).
+    """
+    if len(coords) != NUM_OUTPUTS:
+        raise OrientationInferenceError(
+            f"wbia-orientation '{model_id}': expected {NUM_OUTPUTS} outputs, "
+            f"got {len(coords)}."
+        )
+    bad = [i for i, c in enumerate(coords) if not math.isfinite(float(c))]
+    if bad:
+        raise OrientationInferenceError(
+            f"wbia-orientation '{model_id}': non-finite model output at "
+            f"index/indices {bad}: {coords}"
+        )
 
 
 def compute_theta(coords: Sequence[float]) -> float:
@@ -242,6 +268,15 @@ class WbiaOrientationModel(BaseModel):
                 bbox: Optional[Sequence[float]] = None,
                 theta: float = 0.0,
                 **kwargs) -> Dict[str, Any]:
+        # bbox is required. Defaulting a missing bbox to the full frame would
+        # silently change the region theta describes -- safe-looking, and exactly
+        # the class of silent default this model type exists to remove. A caller
+        # wanting full-frame must say so: bbox=[0, 0, width, height].
+        if bbox is None:
+            raise OrientationInferenceError(
+                f"wbia-orientation '{self.model_id}': bbox is required; pass "
+                f"[0, 0, width, height] explicitly for full-frame."
+            )
         # The reference regressor consumes the AXIS-ALIGNED bbox and infers the
         # rotation itself. Handing it a crop that a detector already rotated would
         # double-rotate. Harmless for lightnet (always 0.0) but wrong for an OBB
@@ -252,7 +287,7 @@ class WbiaOrientationModel(BaseModel):
                 f"derives theta itself; it must not be given a pre-rotated crop "
                 f"(got theta={theta})."
             )
-        return self.predict_batch(image_bytes, [bbox] if bbox is not None else [None])[0]
+        return self.predict_batch(image_bytes, [bbox])[0]
 
     def predict_batch(self, image_bytes: bytes,
                       bboxes: Sequence[Optional[Sequence[float]]]) -> List[Dict[str, Any]]:
@@ -273,15 +308,40 @@ class WbiaOrientationModel(BaseModel):
         image = _canonicalize_rgb(np.asarray(decoded))
         height, width = image.shape[:2]
 
-        results: List[Dict[str, Any]] = []
+        if not bboxes:
+            return []
+
+        # Resolve every bbox first, in input order, so a malformed one fails the
+        # whole call before any inference runs.
+        effs: List[List[int]] = []
         for bbox in bboxes:
-            src = [0, 0, width, height] if bbox is None else list(bbox)
-            eff = resolve_bbox(src, width, height)
+            if bbox is None:
+                raise OrientationInferenceError(
+                    f"wbia-orientation '{self.model_id}': bbox is required; pass "
+                    f"[0, 0, width, height] explicitly for full-frame."
+                )
+            eff = resolve_bbox(list(bbox), width, height)
             if min(eff[2], eff[3]) < 1:
                 eff = [0, 0, width, height]   # reference full-frame fallback
+            effs.append(eff)
 
-            x = self._preprocess(image, eff).to(self.device)
-            coords = self._forward_tta(x)[0].tolist()
+        # Batch: one stacked tensor -> 3 forwards TOTAL (base/hflip/vflip) for the
+        # whole image, rather than 3 per bbox. Order is preserved by construction
+        # (crops are stacked in input order and split back by index), which is
+        # load-bearing: a misaligned row would attach one bbox's theta to
+        # another's crop.
+        batch = torch.cat([self._preprocess(image, e) for e in effs], dim=0)
+        out = self._forward_tta(batch.to(self.device))
+        if out.shape != (len(effs), NUM_OUTPUTS):
+            raise OrientationInferenceError(
+                f"wbia-orientation '{self.model_id}': model returned "
+                f"{tuple(out.shape)}, expected {(len(effs), NUM_OUTPUTS)}."
+            )
+
+        results: List[Dict[str, Any]] = []
+        for eff, row in zip(effs, out):
+            coords = row.tolist()
+            _validate_coords(coords, self.model_id)   # ALL five, not just theta
             th = compute_theta(coords)
             if not math.isfinite(th):
                 # Fail rather than default: 0.0 is a legitimate prediction, so a

--- a/app/routers/pipeline_router.py
+++ b/app/routers/pipeline_router.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from fastapi import APIRouter, HTTPException, Request, status, Depends
 from typing import Dict, Any, List, Optional
 import httpx
@@ -247,6 +248,31 @@ async def run_pipeline(
                                f"{len(wbia_orientation_results)} result(s) for "
                                f"{len(filtered_bboxes)} bbox(es)."
                     )
+                # Validate EVERY row here, not lazily inside the consumer loop.
+                # Checking only the count and then dereferencing per-bbox would let
+                # a malformed row N run classify/extract for rows 0..N-1 before the
+                # request failed -- request-level fail-closed must mean no consumer
+                # runs at all.
+                for idx, ori in enumerate(wbia_orientation_results):
+                    if not isinstance(ori, dict):
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Orientation result {idx} is not an object.")
+                    th_val = ori.get('theta')
+                    if not isinstance(th_val, (int, float)) or isinstance(th_val, bool) \
+                            or not math.isfinite(float(th_val)):
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Orientation result {idx} has a non-finite or "
+                                   f"missing theta: {th_val!r}")
+                    eb = ori.get('effective_bbox')
+                    if (not isinstance(eb, (list, tuple)) or len(eb) != 4
+                            or not all(isinstance(v, int) and not isinstance(v, bool)
+                                       for v in eb)):
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Orientation result {idx} has a malformed "
+                                   f"effective_bbox: {eb!r}")
 
             # Step 3: Run classification and extraction for each filtered bbox
             pipeline_results = []
@@ -264,6 +290,7 @@ async def run_pipeline(
                 bbox_list = [int(x), int(y), int(width), int(height)]
                 theta = float(bbox_prediction.get('theta', 0.0))
                 theta_source = 'detector'
+                detector_bbox = list(bbox_coords)   # audit: what the detector said
 
                 if wbia_orientation_results is not None:
                     ori = wbia_orientation_results[i]
@@ -276,10 +303,14 @@ async def run_pipeline(
                     # crop it rotates.
                     bbox_list = list(ori['effective_bbox'])
                     bbox_coords = bbox_list
-                elif width <= 0 or height <= 0:
-                    # Only skip when orientation is NOT resolving bboxes for us --
-                    # its degenerate-crop fallback needs to see these.
-                    logger.warning(f"Skipping bbox {i}: invalid dimensions width={width}, height={height}")
+                elif bbox_list[2] <= 0 or bbox_list[3] <= 0:
+                    # Guard AFTER integerization: a raw width of 0.5 passes
+                    # `width <= 0` but int(0.5) == 0, so consumers would receive a
+                    # degenerate box. Only skip when orientation is NOT resolving
+                    # bboxes for us -- its degenerate-crop fallback needs to see these.
+                    logger.warning(f"Skipping bbox {i}: invalid dimensions "
+                                   f"width={width}, height={height} "
+                                   f"(integerized to {bbox_list[2]}x{bbox_list[3]})")
                     continue
 
                 # Run orientation, classification, and extraction in parallel
@@ -391,6 +422,7 @@ async def run_pipeline(
                 # Create clean pipeline result entry
                 bbox_result = {
                     'bbox': bbox_coords,
+                    'detector_bbox': detector_bbox,
                     'theta': theta,
                     'theta_source': theta_source,
                     'bbox_score': bbox_prediction.get('score'),

--- a/app/routers/pipeline_router.py
+++ b/app/routers/pipeline_router.py
@@ -10,6 +10,7 @@ from app.models.densenet_classifier import DenseNetClassifierModel
 from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
 from app.models.miewid import MiewidModel
 from app.models.densenet_orientation import DenseNetOrientationModel
+from app.models.wbia_orientation import WbiaOrientationModel, OrientationInferenceError
 from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_response, sanitize_uri_for_logging
 from fastapi.concurrency import run_in_threadpool
 
@@ -119,10 +120,15 @@ async def run_pipeline(
                             "available_models": available_models
                         }
                     )
-                if not isinstance(orientation_model, DenseNetOrientationModel):
+                # Two orientation kinds, dispatched on type:
+                #   DenseNetOrientationModel -> a viewpoint LABEL (legacy)
+                #   WbiaOrientationModel     -> THETA (the rotation regressor)
+                if not isinstance(orientation_model,
+                                  (DenseNetOrientationModel, WbiaOrientationModel)):
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"Model '{pipeline_request.orientation_model_id}' is not a DenseNet orientation model."
+                        detail=f"Model '{pipeline_request.orientation_model_id}' is not a "
+                               f"DenseNet orientation or wbia-orientation model."
                     )
             
             # Resolve image bytes from URI (URL, data URI, or local path)
@@ -202,6 +208,46 @@ async def run_pipeline(
             
             logger.info(f"Found {len(filtered_bboxes)} bboxes above threshold {pipeline_request.bbox_score_threshold}")
             
+            # Step 2b: orientation FIRST, batched, when a theta regressor is
+            # configured. theta must be known before the crop is embedded, so this
+            # cannot run alongside classify/extract in the gather below. One
+            # predict_batch per image = 3 TTA forwards total, not 3 per bbox.
+            #
+            # FAIL-CLOSED, at REQUEST level: if orientation fails for ANY bbox we
+            # return 500 and emit nothing. Falling back to the detector's theta
+            # (lightnet always gives 0.0) would embed an unrotated crop -- exactly
+            # the regression this model type exists to repair. A *predicted* 0.0 is
+            # valid; a *missing* one is not, so it must not be defaulted. Partial
+            # success is also rejected: silently dropping a detection is how
+            # annotations go missing.
+            theta_regressor = isinstance(orientation_model, WbiaOrientationModel)
+            wbia_orientation_results = None
+            if theta_regressor and filtered_bboxes:
+                ori_bboxes = [bp.get('bbox', []) for bp in filtered_bboxes]
+                try:
+                    wbia_orientation_results = await run_in_threadpool(
+                        orientation_model.predict_batch,
+                        image_bytes=image_bytes,
+                        bboxes=ori_bboxes,
+                    )
+                except OrientationInferenceError as e:
+                    logger.error(f"Orientation failed; failing the request: {e}")
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail=f"Orientation model "
+                               f"'{pipeline_request.orientation_model_id}' could not "
+                               f"produce a trustworthy theta: {e}"
+                    )
+                # Ordered 1:1 is load-bearing -- a misaligned row would attach one
+                # bbox's theta to another's crop.
+                if len(wbia_orientation_results) != len(filtered_bboxes):
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail=f"Orientation returned "
+                               f"{len(wbia_orientation_results)} result(s) for "
+                               f"{len(filtered_bboxes)} bbox(es)."
+                    )
+
             # Step 3: Run classification and extraction for each filtered bbox
             pipeline_results = []
             original_classify_results = []
@@ -217,9 +263,22 @@ async def run_pipeline(
                 x, y, width, height = bbox_coords
                 bbox_list = [int(x), int(y), int(width), int(height)]
                 theta = float(bbox_prediction.get('theta', 0.0))
+                theta_source = 'detector'
 
-                # Validate bbox coordinates
-                if width <= 0 or height <= 0:
+                if wbia_orientation_results is not None:
+                    ori = wbia_orientation_results[i]
+                    theta = float(ori['theta'])
+                    theta_source = 'orientation'
+                    # effective_bbox is the slice orientation ACTUALLY used (NumPy
+                    # slicing does not clamp, and a degenerate crop falls back to
+                    # the full frame). classify, extract and the emitted result
+                    # must all use it, or theta describes a region other than the
+                    # crop it rotates.
+                    bbox_list = list(ori['effective_bbox'])
+                    bbox_coords = bbox_list
+                elif width <= 0 or height <= 0:
+                    # Only skip when orientation is NOT resolving bboxes for us --
+                    # its degenerate-crop fallback needs to see these.
                     logger.warning(f"Skipping bbox {i}: invalid dimensions width={width}, height={height}")
                     continue
 
@@ -245,7 +304,7 @@ async def run_pipeline(
                 tasks.append(extract_task)
                 task_names.append('extract')
 
-                if orientation_model:
+                if orientation_model and not theta_regressor:
                     orientation_task = run_in_threadpool(
                         orientation_model.predict,
                         image_bytes=image_bytes,
@@ -333,6 +392,7 @@ async def run_pipeline(
                 bbox_result = {
                     'bbox': bbox_coords,
                     'theta': theta,
+                    'theta_source': theta_source,
                     'bbox_score': bbox_prediction.get('score'),
                     'detection_class': bbox_prediction.get('class'),
                     'detection_class_id': bbox_prediction.get('class_id'),

--- a/docs/plans/2026-07-16-wbia-orientation-theta-design.md
+++ b/docs/plans/2026-07-16-wbia-orientation-theta-design.md
@@ -1,0 +1,456 @@
+# wbia-orientation: restore theta for whale sharks
+
+Design for a new ml-service model type that runs `wbia-plugin-orientation`
+checkpoints as the **oriented-bbox regressors they are**, returning **theta**,
+and wires that theta into `/pipeline/`.
+
+Related: issue #33 (fabricated viewpoint labels), PR #34 (stop fabricating).
+
+**Revision 6** — after five design-review rounds (r1: 3C/6M; r2: 2C/3M; r3: 2C/3M;
+r4: 1C/1M; r5: 1C/2M). Newest changes marked ▲▲▲▲▲.
+
+## Problem
+
+Sharkbook lost annotation rotation when it moved to the v2 ml-service in June
+2026. Measured on its production DB (`FEATURE."REVISION"` monthly histogram,
+`IACLASS='whaleshark'`):
+
+| month | theta_zero | theta_real | % zero |
+|---|---|---|---|
+| 2025-02 → 2026-05 (16 mo) | ~230 | ~9,200 | **~2–4%** |
+| 2026-06 | 132 | 96 | **58%** |
+| 2026-07 | **186** | **4** | **98%** |
+
+~315 whale shark annotations have `theta = 0` that should carry a real rotation.
+
+**Cause.** `theta` in `/pipeline/` comes only from the *detector*
+(`pipeline_router.py:189,222`). Whale sharks detect with `whaleshark_v0`, a
+**lightnet** model, and `lightnet_model.py` never emits `thetas` — so
+`pipeline_router:198` defaults it to `0.0`. Under WBIA, theta came from
+`orientation.whaleshark.v3` via `wbia-plugin-orientation`. ml-service loaded that
+checkpoint under `densenet-orientation`, which treats it as a 5-class classifier
+(issue #33), so it produced a garbage viewpoint label and **never produced theta
+at all**.
+
+**Why this outranks #33.** A wrong viewpoint corrupts the candidate *filter*. A
+missing theta means the crop was never rotated, so **MiewID embedded a tilted
+animal** — the embedding is wrong at the source, and every match touching those
+annotations is degraded, including matches initiated from healthy ones. #33 is
+recoverable by nulling a column; this is only recoverable by re-extracting
+embeddings.
+
+## What the checkpoint actually is
+
+The 5 outputs are `[xc, yc, xt, yt, w]`, **normalized to [0,1]** —
+`wbia_orientation/_plugin.py:326-340`:
+
+> `output (torch tensor): tensor of shape (bs, 5) ... coords are between 0 and 1`
+
+They are in [0,1] because the head is **sigmoid**, not softmax
+(`models/orientation_net.py:64`) — which is why softmaxing them yields ~0.2
+"probabilities".
+
+▲ **All three deployed checkpoints verified structurally identical**: `whaleshark.v3`,
+`leopard_shark.v0`, `salamander_fire_adult.v2` each expose
+`model.classifier.weight` of `(5, 2048)`, carry HRNet `stage2/stage3` keys, and
+declare **no `classes`**. ▲ **No species YAML overrides** `MODEL.IMSIZE`,
+`MODEL.CORE_NAME`, `TEST.HFLIP` or `TEST.VFLIP` (grepped across
+`wbia_orientation/config/*.yaml`), so `config/default.py` values apply. NB
+leopard shark and salamander are not in the plugin's `CONFIGS` map at all —
+newer models trained on the same pipeline.
+
+## Reference algorithm (authoritative)
+
+Sources: `_plugin.py:189-296` (inference), `dataset/animal_wbia.py:17-37`
+(preprocess), `models/orientation_net.py:63-95` (head + TTA),
+`utils/utils.py:88-116` (un-flip), `core/evaluate.py:9-20` (theta).
+
+0. ▲▲ **Decode with `imageio`**, matching `animal_wbia.py:18` (`imageio.imread`),
+   reading from bytes rather than a path. This is **not** interchangeable with
+   ml-service's existing decoders — the paths diverge on non-RGB inputs:
+
+   | | grayscale | RGBA |
+   |---|---|---|
+   | `imageio.imread` (reference) | `(H,W)` 2-D | `(H,W,4)` |
+   | `cv2.imdecode(IMREAD_COLOR)` (`densenet_orientation.py:168`) | forced `(H,W,3)` | forced `(H,W,3)` |
+   | `PIL.convert('RGB')` (`miewid.py:186`) | `(H,W,3)` | `(H,W,3)` |
+
+   ▲▲▲ **Non-RGB policy — revision 3 was incoherent and is corrected.** It called
+   grayscale/RGBA "fidelity strata", but **the reference cannot produce a theta from
+   either** — its `Normalize(3-channel)` rejects them. Measured:
+
+   ```
+   grayscale (H,W)  -> RuntimeError: output with shape [1,224,224] doesn't match broadcast shape [3,...]
+   RGBA (H,W,4)     -> RuntimeError: size of tensor a (4) must match tensor b (3)
+   RGB (H,W,3)      -> tensor (1,3,224,224)   OK
+   ```
+
+   There is no reference angle to compare against, so that stratum was asking the
+   gate to diff against a crash.
+
+   **Policy: canonicalize to RGB before crop** — grayscale replicated to 3 channels,
+   RGBA alpha dropped. This is an **explicit, documented deviation**: the reference's
+   only "behaviour" here is an exception, which is not a specification, and failing a
+   whole detection because a frame is grayscale (common for IR/night captures) is
+   worse than handling it.
+
+   **The wrapper is validated, not assumed**: convert the fixture to RGB *outside*
+   and run the **reference** on it; run the **port** on the original; require the
+   same circular-error thresholds. That makes canonicalization a tested transform
+   rather than a silent one. Pure-fidelity strata stay **RGB-only**, where a
+   reference exists.
+
+1. Crop the **axis-aligned** bbox: `image[y1:y1+h, x1:x1+w]`.
+   ▲ **Empty/degenerate-crop fallback** (`animal_wbia.py:25-28`): if
+   `min(image.shape) < 1`, reload the **full image** and replace the bbox with
+   `[0, 0, width, height]`. This changes the model's input and must be ported.
+
+   ▲▲▲ **`effective_bbox` — revision 3 was not end-to-end sound.** The fallback
+   silently *changes which region the theta describes*. If orientation falls back to
+   the full image but classify/extract still receive the original degenerate bbox,
+   the theta belongs to a different region than the crop it rotates — a new
+   silently-wrong value, i.e. the #33 failure mode again.
+
+   ▲▲▲▲ **"valid → use as-is" was still unsafe: NumPy slicing does not clamp.**
+   `image[y1:y1+h, x1:x1+w]` resolves negative indices **from the far edge**, so an
+   out-of-image bbox does not fail — it silently crops the wrong region. Measured on
+   a 400px-wide image with the far-right 20 columns marked:
+
+   | bbox | reference crop | far-edge content? | `slice().indices()` |
+   |---|---|---|---|
+   | `x1=-20, w=50` | width **0** (empty) | no | `[380:30]` |
+   | **`x1=-20, w=500`** | width **20** | **YES** | `[380:400]` |
+   | `x1=380, w=50` (overrun) | width **20** (truncated) | yes | `[380:400]` |
+
+   A negative origin with a wide box crops the **far edge**; an overrun silently
+   **truncates**. In both, theta would describe a region the detector never pointed
+   at, while classify/extract — which clamp differently — crop somewhere else.
+   `effective_bbox` alone does not fix this; the *resolution rule* must match.
+
+   **Bbox policy — resolve the ACTUAL reference slice, then reuse it everywhere:**
+   1. Validate finite numeric values; **fail the whole request (500)** on
+      malformed/non-finite/NaN, before any consumer runs.
+   2. Apply one explicit integerization rule (documented; no implicit float→int).
+   3. Derive the real slice with `slice(start, stop).indices(dim)` — reproducing
+      exactly what NumPy did, including the far-edge and truncation cases above.
+   4. **Non-empty** → that in-bounds slice **is** `effective_bbox`.
+      **Empty** → reference full-frame fallback, `effective_bbox = [0,0,W,H]`.
+   5. Feed `effective_bbox` to **both** classify and extract, so all three consumers
+      see the identical region.
+   6. ▲▲▲▲▲ **Emit `effective_bbox` as the result's `bbox`.** Fixing only the internal
+      consumers is not enough: `/pipeline/` emits `'bbox': bbox_coords`
+      (`pipeline_router.py:334`) and Wildbook persists exactly that alongside theta via
+      `MlServiceProcessor.featureParams(bbox, theta, viewpoint)`. Leaving the detector's
+      original bbox in the result would store a bbox naming one region beside a theta
+      describing another — the same mismatch, one layer further out. For
+      `WbiaOrientationModel`, the result's `bbox` **is** `effective_bbox`; the raw
+      detector bbox is retained only as a separate audit field (`detector_bbox`).
+
+   ▲▲▲▲▲ **Integerization rule: `int()`, truncate-toward-zero, applied once** to each of
+   `[x, y, w, h]` before deriving `start`/`stop`. This is not a new invention — it is
+   what `pipeline_router.py:218` already does (`bbox_list = [int(x), int(y), int(width),
+   int(height)]`). Declaring it matters because truncate/floor/round give materially
+   different slices for negative fractional coordinates (`int(-0.5) == 0`, but
+   `floor(-0.5) == -1`, which then resolves from the far edge). Test fractional
+   **negative and positive** inputs.
+
+   ▲▲▲▲▲ **Pre-existing inconsistency, noted:** today the emitted bbox
+   (`bbox_coords`, raw, possibly float) differs from the consumed bbox (`bbox_list`,
+   int-truncated) — so Wildbook already persists a bbox the embedding did not use. It
+   is sub-pixel and harmless in practice, but it is the same bug class; this design
+   closes it for the orientation path by emitting a single authoritative bbox.
+
+   Tests: negative origin (narrow **and** wide), overrun, fully out-of-image,
+   non-finite. NB `pipeline_router:225` today skips zero/negative-dimension bboxes
+   *before* orientation; that skip must move behind this policy or the fallback can
+   never fire.
+2. Resize to `MODEL.IMSIZE = [224, 224]` with
+   `skimage.transform.resize(..., order=3, anti_aliasing=True)` (bicubic).
+3. `ToTensor()` then `Normalize(mean=[0.485,0.456,0.406], std=[0.229,0.224,0.225])`.
+   NB `skimage.resize` returns float64 in [0,1], so `ToTensor` does **not**
+   rescale by 255.
+4. ▲ **Cast to float32 immediately before inference** — `_plugin.py:272` calls
+   `model(images.float(), ...)` precisely because skimage yields float64.
+5. `out = sigmoid(hrnet(x))` → `(1,5)` in [0,1].
+6. **TTA (on by default: `TEST.HFLIP=True`, `TEST.VFLIP=True`)**
+   - `out_h = sigmoid(hrnet(flip(x, dim=3)))`; un-flip with `image_h_w=[1.0,1.0]`:
+     `out_h[0] = 1 - out_h[0]`, `out_h[2] = 1 - out_h[2]`
+   - `out_v = sigmoid(hrnet(flip(x, dim=2)))`; un-flip:
+     `out_v[1] = 1 - out_v[1]`, `out_v[3] = 1 - out_v[3]`
+   - `out = (out + out_h + out_v) / 3`
+   - Recursion terminates: the inner `self.forward(flipped)` passes no flip args,
+     so both default to `False`.
+7. `theta = arctan2(out[3] - out[1], out[2] - out[0]) + radians(90)`
+
+Theta is computed on the **normalized** coords, *before* `resize_oa_box`
+(`orientation_post_proc` calls `compute_theta` first, then mutates `output`). A
+theta-only port may skip the box resize — ▲ but any returned `coords` must be
+labelled **normalized**, never image-space.
+
+## Design
+
+### 1. New model type `wbia-orientation`
+
+New `app/models/wbia_orientation.py` → `WbiaOrientationModel`, registered in
+`MODEL_REGISTRY`. Distinct from `densenet-orientation` (genuine viewpoint
+classifiers; currently none — see #34).
+
+- **Load**: `timm.create_model('hrnet_w32', pretrained=False, num_classes=5)`,
+  strip `model.`/`module.` prefixes, `load_state_dict` **strict**. ▲ A strict load
+  of each of the three checkpoints runs in the host preflight (not CI — the weights
+  cannot be committed), not as an assumption.
+
+  ▲▲ **timm-vs-reference equivalence: PROVEN, not assumed.** Revision 1 argued
+  "strict load succeeds, so the architecture matches" — that is invalid reasoning
+  (strict load establishes key/shape compatibility, not identical forward
+  computation), and the reference builds
+  `wbia_orientation.models.cls_hrnet.HighResolutionNet`, not timm. So it was
+  measured. Both models were constructed, the **same** `orientation.whaleshark.v3`
+  weights loaded into each (`missing=0, unexpected=0` both), and the same input run
+  through both in eval/no-grad:
+
+  ▲▲▲ **Extended to 3 checkpoints x 6 inputs = 18 comparisons** (revision 2's single
+  checkpoint/input did not justify the word "PROVEN"). Every checkpoint strict-loads
+  into both; inputs span noise (2 seeds), zeros, ones, ImageNet-scaled, and a batch
+  of 3:
+
+  ```
+  WORST over 3 checkpoints x 6 inputs : 5.960e-08
+  ```
+
+  `5.96e-08` is exactly **1 ULP of float32** (2^-24) — floating-point op-ordering
+  noise, not an architectural difference. Note the reference's `get_cls_net` builds a
+  1000-class head that `OrientationNet` replaces with `nn.Linear(2048, 5)`; the
+  comparison reproduces that.
+
+  ▲▲▲ **Where it runs.** The checkpoints are hundreds of MB and cannot be committed,
+  so this cannot be a normal CI test — and a *skipped* test is not a safeguard. It
+  therefore runs as part of the release-blocking **host preflight** (below), where
+  the weights exist — not as a CI test. If it ever fails, vendor `cls_hrnet`.
+- **No label_map, no classes.** Must never be usable in the classify slot.
+- ▲▲▲▲ **API contract** (revision 4 promised `effective_bbox` and batching in prose
+  but declared neither):
+
+  ```python
+  predict(image_bytes, bbox) -> {
+      "model_id": str,
+      "theta": float,                    # radians; finite, else the request fails
+      "coords_normalized": [xc, yc, xt, yt, w],   # [0,1]; NEVER image-space
+      "effective_bbox": [x, y, w, h],    # the ACTUAL slice used (see bbox policy)
+  }
+
+  predict_batch(image_bytes, bboxes) -> [result, ...]
+      # exactly ONE ordered result per input bbox, or ATOMIC failure.
+      # Callers must assert len(results) == len(bboxes) before any consumer runs.
+  ```
+
+  `predict_batch` is the router's entry point (orientation batches across an image's
+  bboxes, incl. TTA passes). Ordered one-per-bbox is load-bearing: a silently
+  misaligned result would attach one bbox's theta to another's crop.
+
+  ▲ No `label`, no `probability`, no `class_id` — nothing a viewpoint consumer
+  could mistake for a classification (the #33 failure mode).
+- ▲ **Accepts no input theta.** The reference consumes the *axis-aligned* bbox;
+  feeding it a detector-rotated crop would double-rotate. The signature takes
+  image bytes + bbox only, and rejects a non-zero theta if one is passed.
+
+### 2. `pipeline_router` wiring
+
+- Keep `orientation_model_id`; dispatch on model type — `DenseNetOrientationModel`
+  (label, legacy) or `WbiaOrientationModel` (theta).
+- ▲ **Fail-closed, at REQUEST level.** Orientation currently soft-fails and
+  continues. For `WbiaOrientationModel` that is unacceptable: a failure, malformed
+  result or NaN would fall back to the detector's `0.0` and embed an unrotated crop
+  — *the exact bug being repaired*. A **predicted `0.0` is valid** and must be
+  distinguished from missing/failed.
+
+  ▲▲ **Scope (revision 2 was contradictory).** "5xx and emit no result for that
+  bbox" is incoherent: a 5xx body cannot also carry successful siblings, and
+  partial success would silently drop detections. **If orientation fails for ANY
+  bbox requiring it, the whole request fails: one request-level `500`, no results,
+  and neither classify nor extract runs for any bbox.** Dropping a detection
+  silently is how annotations go missing; failing loudly is recoverable.
+  `500` is correct for a malformed/non-finite result or internal inference failure;
+  reserve `503` for genuinely transient dependency/resource failures.
+  Test: two bboxes, one returns NaN → whole request 500, and assert classify/extract
+  were never invoked.
+- ▲ **Ordering and batching.** Theta must precede both consumers, so
+  `asyncio.gather` over (orientation ∥ classify ∥ extract) is wrong. New shape:
+  `detect → orientation (batched across all bboxes, incl. TTA passes) → per-bbox
+  (classify ∥ extract)`. Do **not** spawn competing per-bbox GPU orientation
+  threads. Latency budget: measure p50/p95 on the T4 at representative detection
+  counts before rollout; adds 3 forward passes per bbox.
+- Set the result's `theta` from orientation, overriding the detector's; emit
+  `theta_source: "orientation"|"detector"` for auditability.
+
+### 3. Wildbook (Java) — no change required ▲ *verified, not assumed*
+
+`MlServiceProcessor.persistDetections` iterates `results` and reads each entry's
+theta, persisting it unmodified:
+
+```java
+for (int i = 0; i < results.length(); i++) {
+    JSONObject result = results.getJSONObject(i);   // :366
+    double theta = result.getDouble("theta");       // :368
+    ...
+    JSONObject featureParams = featureParams(bbox, theta, viewpoint);  // :475
+```
+
+theta is not reassigned between :368 and :475. ▲ Still gated on an end-to-end
+contract test asserting a non-zero orientation theta reaches `FEATURE.PARAMETERS`
+— reading code is not proof.
+
+▲ **Dedup interaction (found while verifying the above):**
+`findExistingAnnotation(ma, bbox, theta)` (:417) dedups on bbox **and** theta. So
+re-running detection over an affected asset would **not** match its `theta=0` row
+and would create a **duplicate**. The backfill must update in place — never
+re-detect.
+
+### 4. Config and rollout ▲
+
+Re-add the three checkpoints under new `-theta` ids (so nothing can resolve the
+old classifier semantics):
+
+```json
+{ "model_id": "whaleshark_v3-theta", "model_type": "wbia-orientation",
+  "checkpoint_path": "/datasets/orientation.whaleshark.v3.pth", "imsize": [224, 224] }
+```
+
+**Risk**: `main.py` eager-loads every entry and re-raises, so a bad entry downs a
+service shared by 5 installs. The registry is also a single shared file (see the
+`MODEL_CONFIG` mount issue).
+
+▲▲ **Revision 2 claimed "other installs are unaffected by config they do not
+name". That is materially FALSE and is struck.** `main.py` loads *every* entry in
+the shared `model_config.json` at startup regardless of which install references
+it — so an install that never names `whaleshark_v3-theta` still loads it, and still
+dies if its checkpoint is missing or its architecture is incompatible on that box.
+**Naming isolation is not startup isolation.** This is not hypothetical: on
+2026-07-16 a config/code mismatch on exactly this path took the shared service down
+for all installs.
+
+Mitigations, in order:
+1. **Startup preflight on the actual host**, with its real `/datasets` mount and
+   GPU — not merely a local load. Local success does not predict the box.
+2. Deploy code first (inert until config names the new type), then config.
+3. Stage-load all three checkpoints against the new code before rollout.
+
+Per-install model configuration is the real fix — it is the only thing that makes
+startup risk proportional to which install needs a model. It is an architectural
+change to the shared registry, out of scope here, and **should be filed**
+alongside the `MODEL_CONFIG` mount fix.
+
+## Dependency pins ▲▲
+
+Revision 2 said "add and pin `scikit-image`" without naming versions — not a
+specification. Interpolation and anti-alias behaviour are version-sensitive, and
+so is `imageio` decoding. **Pin the exact versions the fidelity gate was executed
+against**, record them here, and re-run the gate on any bump:
+
+▲▲▲ Resolved and recorded (placeholders were not pins):
+
+```
+scikit-image==0.26.0      # resize(order=3, anti_aliasing=True)
+imageio==2.37.3           # decode; backend below is part of the contract
+pillow==12.1.1            # imageio's JPEG/PNG backend -- decoding is NOT
+                          # reproducible from the imageio pin alone
+numpy==1.26.4
+torch==2.10.0+cu128       # the tested stack; equivalence + gate are
+timm==1.0.25              # only valid against these
+```
+
+Both scikit-image and imageio are **new dependencies on a service shared by 5
+installs** — which is itself why the host preflight above is mandatory. Re-run the
+fidelity gate on any bump to any line here, including the Pillow backend.
+
+## Validation ▲ — the gate is reference-vs-port, not legacy agreement
+
+Revision 1 proposed "agreement against ≥200 legacy stored thetas". That is **not a
+fidelity oracle**: it has no threshold, ignores angular wraparound, and compares
+to historical annotation state rather than to the authoritative implementation.
+
+**Primary gate (fidelity).** The plugin source and all three checkpoints are
+available locally, so the reference can be executed directly — no WBIA test DB
+needed. Run reference and port over production image bytes + bboxes and compare
+per sample with circular error (handles wraparound):
+
+```
+d = abs(atan2(sin(theta_ref - theta_port), cos(theta_ref - theta_port)))
+```
+
+▲▲ **CI/release-blocking, with a checked-in manifest.** Revision 2's "≥200
+stratified" was too vague to mean anything, and `1e-3 rad` tolerates a 0.057°
+outlier — not "near exact" for a port of the same math onto the same weights on
+the same device.
+
+- **Thresholds: `max ≤ 1e-5 rad`, `mean ≤ 1e-6 rad`.** Relax only with measured,
+  documented platform variance — never to make a failing port pass.
+▲▲▲▲ **Input manifest, live comparison — NOT frozen expected values.** The weights
+cannot live in CI, so the gate runs at host preflight and executes **the pinned
+reference and the port live, comparing them to each other**. Freezing expected
+thetas would only pin one implementation's output and rot on any dependency bump;
+frozen values are an optional diagnostic baseline, never the oracle.
+
+The checked-in manifest carries **inputs and identity**, not answers:
+- fixture **byte hashes** + exact bboxes (immutable fixture identity)
+- **checkpoint SHA-256s**
+- reference-source **revision/hash** (which `wbia-plugin-orientation` commit)
+- stratum tags with **enforced per-stratum minimums** (fail if unmet)
+
+The preflight emits an artifact recording reference outputs, port outputs, and the
+full environment versions.
+
+**Compared per sample**, each with its own acceptance criterion (revision 5 compared
+coordinates but only set thresholds for theta, which made that half unenforceable):
+
+| compared | criterion |
+|---|---|
+| theta | circular error `abs(atan2(sin Δ, cos Δ))`: **max ≤ 1e-5 rad, mean ≤ 1e-6 rad** |
+| `coords_normalized` | elementwise absolute error: **max ≤ 1e-6, mean ≤ 1e-7** |
+| `effective_bbox` | **exact equality** (integers; no tolerance) |
+| `predict_batch` | **exact count and order** vs input bboxes |
+
+Coordinate tolerance cannot be exact equality: measured model variance is ~1 ULP of
+float32 (5.96e-08) on outputs in [0,1], so 1e-6 max leaves ~17x headroom over
+observed noise while still failing any real preprocessing divergence. Theta alone can
+pass while coordinates are wrong, so both are required.
+
+- **Coverage: all three checkpoints** (whaleshark_v3, leopard_shark_v0,
+  salamander_fire_adult_v2), with per-stratum minimums, over strata that can each
+  independently break the port:
+  | stratum | why |
+  |---|---|
+  | codec / channel form: RGB JPEG, **grayscale**, **RGBA PNG** | decode paths diverge here (see step 0) |
+  | crop **downscale** (crop ≫ 224) | skimage's anti-alias prefilter only engages downscaling |
+  | crop **upscale** (crop ≪ 224) | different interpolation regime |
+  | extreme aspect ratios | resize distortion feeds theta |
+  | bbox edge / degenerate / out-of-image | exercises the reload-full-image fallback |
+  | multi-detection images | exercises orientation batching |
+- Reference and port must run **same device, same dtype, eval + no_grad, autocast
+  disabled** — otherwise the comparison measures the harness, not the port.
+
+**Secondary (model quality, not a gate).** Compare port theta against the ~9,200
+legacy real thetas, using the same circular metric. Disagreement here is
+informative (drift, or the legacy value was human-edited) but must not block.
+
+**Unit tests.** sigmoid not softmax; un-flip index arithmetic (`1-x` on `0,2` for
+h and `1,3` for v); 3-way mean; `+90°`; float32 cast; degenerate-crop fallback;
+hand-computed theta (`[0.5,0.5,1.0,0.5,0.1]` → `arctan2(0,0.5)+90° = 90°`); no
+`label`/`probability` key ever emitted; rejected from the classify slot; NaN theta
+→ fail-closed, not 0.0.
+
+## Backfill pathway (separate PR)
+
+For the ~315 affected annotations, theta must be recomputed **and embeddings
+re-extracted** — the existing embeddings came from unrotated crops.
+
+1. Identify: `FEATURE."REVISION" >= 2026-06-01` AND `theta = 0` AND
+   `IACLASS IN ('whaleshark', <leopard shark class>)`.
+2. Recompute theta via the orientation model.
+3. **Update `FEATURE."PARAMETERS"` theta in place** — ▲ never re-detect (dedup is
+   theta-sensitive; re-detection would duplicate the annotation).
+4. Re-extract the embedding via `/extract/` **with the corrected theta**.
+5. Bump `ANNOTATION."VERSION"` so OpenSearch reindexes.
+
+Shape it like `appadmin/catchUpEmbeddings.jsp`. Order matters: theta must be
+written before re-extraction, or the new embedding repeats the original error.

--- a/docs/plans/2026-07-16-wbia-orientation-theta-design.md
+++ b/docs/plans/2026-07-16-wbia-orientation-theta-design.md
@@ -349,15 +349,32 @@ against**, record them here, and re-run the gate on any bump:
 
 ▲▲▲ Resolved and recorded (placeholders were not pins):
 
+▲▲▲▲▲▲ **Corrected to the ACTUAL production stack.** Revision 5 recorded the
+versions from a convenience venv (`--system-site-packages`, so it inherited
+pillow 12.1.1 / numpy 1.26.4 / timm 1.0.25) — which are NOT what `requirements.txt`
+pins. The gate had therefore proven fidelity for a stack production does not
+install: the same "measured the convenient artifact" error this whole change
+exists to correct. Both gates were **re-run against the real pins** and produce
+identical numbers (timm 1.0.19 equivalence 5.960e-08; fidelity theta 7.726e-07,
+coords 1.192e-07).
+
+Only `scikit-image` and `imageio` are NEW. `Pillow` was already pinned and stays
+put — bumping it on a service shared by five installs is out of scope here — but
+it is part of this contract, because imageio's decoding is not reproducible from
+the imageio pin alone.
+
 ```
-scikit-image==0.26.0      # resize(order=3, anti_aliasing=True)
-imageio==2.37.3           # decode; backend below is part of the contract
-pillow==12.1.1            # imageio's JPEG/PNG backend -- decoding is NOT
-                          # reproducible from the imageio pin alone
-numpy==1.26.4
-torch==2.10.0+cu128       # the tested stack; equivalence + gate are
-timm==1.0.25              # only valid against these
+scikit-image==0.26.0      # NEW: resize(order=3, anti_aliasing=True)
+imageio==2.37.3           # NEW: decode
+Pillow==10.1.0            # pre-existing; imageio's JPEG/PNG backend
+numpy==1.26.3             # pre-existing
+timm==1.0.19              # pre-existing; equivalence re-verified on THIS version
+torch==2.10.0+cu128
 ```
+
+The gate, its input manifest, and the reference runner live in
+`scripts/preflight/` and are release-blocking on the host. Re-run on ANY bump to
+these lines.
 
 Both scikit-image and imageio are **new dependencies on a service shared by 5
 installs** — which is itself why the host preflight above is mandatory. Re-run the

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ transformers==4.52.4
 opencv-python==4.8.1.78
 # wbia-orientation (app/models/wbia_orientation.py) must reproduce the reference
 # preprocessing exactly -- its output IS an angle, so a resize/decode mismatch is
-# angular error. skimage's anti_aliasing Gaussian prefilter on downscale has no
-# cv2 equivalent. Pillow is pinned because imageio's decoding is not reproducible
-# from the imageio pin alone. Re-run the host preflight fidelity gate on ANY bump
-# to these three.
+# angular error, and skimage's anti_aliasing Gaussian prefilter on downscale has
+# no cv2 equivalent. imageio's decoding also depends on its Pillow backend, which
+# is already pinned above (Pillow==10.1.0) -- that pin is part of this contract.
+# Re-run the host preflight fidelity gate on ANY bump to scikit-image, imageio,
+# Pillow, or timm.
 scikit-image==0.26.0
 imageio==2.37.3
-pillow==12.1.1
 aiofiles==23.2.1
 python-jose==3.3.0
 passlib==1.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,15 @@ Pillow==10.1.0
 numpy==1.26.3
 transformers==4.52.4
 opencv-python==4.8.1.78
+# wbia-orientation (app/models/wbia_orientation.py) must reproduce the reference
+# preprocessing exactly -- its output IS an angle, so a resize/decode mismatch is
+# angular error. skimage's anti_aliasing Gaussian prefilter on downscale has no
+# cv2 equivalent. Pillow is pinned because imageio's decoding is not reproducible
+# from the imageio pin alone. Re-run the host preflight fidelity gate on ANY bump
+# to these three.
+scikit-image==0.26.0
+imageio==2.37.3
+pillow==12.1.1
 aiofiles==23.2.1
 python-jose==3.3.0
 passlib==1.7.4

--- a/scripts/preflight/README.md
+++ b/scripts/preflight/README.md
@@ -1,0 +1,56 @@
+# wbia-orientation host preflight
+
+Release-blocking. **Run on the ml-service host**, with its real `/datasets` mount
+and GPU, before `wbia-orientation` config is deployed.
+
+Not CI: the checkpoints are hundreds of MB and cannot be committed — and a
+*skipped* test is not a safeguard.
+
+## Why it exists
+
+`app/models/wbia_orientation.py` ports `wbia-plugin-orientation`. Its failure
+mode is being **silently wrong by an angle**, which downstream is
+indistinguishable from correct output — the same class of bug as #33, whose
+fabricated viewpoint labels went unnoticed for two months. The only trustworthy
+oracle is the reference implementation itself, executed live on the same bytes.
+
+## What it checks
+
+1. **Architecture equivalence** — reference `cls_hrnet` vs `timm hrnet_w32` on the
+   same weights. Justifies not vendoring. Measured: 3 checkpoints × 6 inputs,
+   worst `5.960e-08` (1 ULP of float32).
+2. **Fidelity** — reference vs port over `manifest.json`'s fixtures. Measured on
+   whaleshark_v3: theta `7.726e-07` rad, coords `1.192e-07`.
+3. **Strict load** of each deployed checkpoint.
+
+Compared per sample: circular theta error, elementwise `coords_normalized`,
+`effective_bbox` exact equality, and `predict_batch` count/order. Theta alone can
+pass while coordinates are wrong.
+
+## Running it
+
+```bash
+python scripts/preflight/run_gate.py --manifest scripts/preflight/manifest.json \
+                                     --fixtures /path/to/fixtures
+```
+
+Emits an artifact recording reference outputs, port outputs, and the full
+environment. **Re-run on any bump to `scikit-image`, `imageio`, `Pillow`, `timm`,
+`torch`, or `numpy`** — `imageio`'s decoding is not reproducible from its own pin
+alone, which is why Pillow is part of the contract.
+
+`reference_runner.py` loads the plugin's config and `cls_hrnet` via `importlib`,
+bypassing the `wbia` package import (which needs a full WBIA install). `utool` is
+only required for pretrained-weight download, which we skip.
+
+## Environment the gate was last validated against
+
+Matches `requirements.txt`, not a convenience venv — an earlier run validated
+`pillow 12.1.1 / numpy 1.26.4 / timm 1.0.25` while requirements pinned
+`10.1.0 / 1.26.3 / 1.0.19`, i.e. it proved fidelity for a stack production does
+not install.
+
+```
+Pillow==10.1.0     scikit-image==0.26.0    torch==2.10.0+cu128
+numpy==1.26.3      imageio==2.37.3         timm==1.0.19
+```

--- a/scripts/preflight/manifest.json
+++ b/scripts/preflight/manifest.json
@@ -1,0 +1,40 @@
+{
+  "_note": "INPUT manifest for the wbia-orientation fidelity gate. It carries inputs and identity, NOT expected answers: the gate executes the pinned reference and the port LIVE and compares them to each other. Frozen expected thetas would only pin one implementation's output and would rot on any dependency bump.",
+  "reference_source": {
+    "repo": "wbia-plugin-orientation",
+    "path": "/mnt/c/wbia-plugin-orientation",
+    "_note": "record the commit hash of the reference checkout used for the gate run"
+  },
+  "thresholds": {
+    "theta_circular_max_rad": 1e-5,
+    "theta_circular_mean_rad": 1e-6,
+    "coords_elementwise_max": 1e-6,
+    "coords_elementwise_mean": 1e-7,
+    "effective_bbox": "exact",
+    "predict_batch": "exact count and order"
+  },
+  "checkpoints": [
+    {"model_id": "whaleshark_v3-theta",
+     "path": "/datasets/orientation.whaleshark.v3.pth",
+     "sha256": "<record at preflight>"},
+    {"model_id": "leopard_shark_v0-theta",
+     "path": "/datasets/orientation.leopard_shark.v0.pth",
+     "sha256": "<record at preflight>"},
+    {"model_id": "salamander_fire_v2-theta",
+     "path": "/datasets/orientation.salamander_fire_adult.v2.pth",
+     "sha256": "<record at preflight>"}
+  ],
+  "strata": {
+    "_note": "Each stratum can independently break the port. Fidelity strata are RGB-only: the reference RAISES on grayscale/RGBA, so there is no reference angle to compare against. The RGB-canonicalization wrapper is validated separately by converting the fixture to RGB externally and running the reference on that.",
+    "rgb_jpeg_downscale": {"min_samples": 20, "_why": "crop >> 224; skimage's anti-alias prefilter only engages downscaling"},
+    "rgb_jpeg_upscale": {"min_samples": 10, "_why": "crop << 224; different interpolation regime"},
+    "extreme_aspect": {"min_samples": 10, "_why": "resize distortion feeds theta"},
+    "bbox_edge_degenerate": {"min_samples": 10, "_why": "exercises the reload-full-image fallback and NumPy's non-clamping slice"},
+    "multi_detection": {"min_samples": 10, "_why": "exercises orientation batching and row/bbox alignment"},
+    "canonicalization_wrapper": {"min_samples": 10, "_why": "grayscale/RGBA: port on the original vs reference on an externally RGB-converted copy"}
+  },
+  "fixtures": [
+    {"_note": "populate with production image byte hashes + exact bboxes + stratum tag",
+     "sha256": "<fixture byte hash>", "bbox": [0, 0, 0, 0], "stratum": "rgb_jpeg_downscale"}
+  ]
+}

--- a/scripts/preflight/reference_runner.py
+++ b/scripts/preflight/reference_runner.py
@@ -1,0 +1,63 @@
+"""Execute the wbia-plugin-orientation REFERENCE inference standalone.
+
+Loads the plugin's own config + cls_hrnet via importlib (bypassing the `wbia`
+package import), reproduces OrientationNet (classifier->5, sigmoid, hflip/vflip
+TTA) and AnimalWbiaDataset preprocessing exactly, and returns theta.
+
+This is the fidelity oracle: the port must agree with THIS, not with a stored
+value or a human's expectation.
+"""
+import importlib.util, math, sys
+import numpy as np, torch, torch.nn as nn, imageio.v2 as imageio, io
+from collections import OrderedDict
+from skimage.transform import resize as sk_resize
+from torchvision import transforms
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec); sys.modules[name] = m
+    spec.loader.exec_module(m); return m
+
+_R = "/mnt/c/wbia-plugin-orientation/wbia_orientation/"
+_cfg = _load("wd_cfg", _R + "config/default.py")._C.clone()
+_cls = _load("wd_hrnet", _R + "models/cls_hrnet.py")
+_utils = _load("wd_utils", _R + "utils/utils.py")
+_eval = _load("wd_eval", _R + "core/evaluate.py")
+
+_T = transforms.Compose([transforms.ToTensor(),
+     transforms.Normalize(mean=[0.485,0.456,0.406], std=[0.229,0.224,0.225])])
+
+class Reference:
+    def __init__(self, ckpt):
+        m = _cls.HighResolutionNet(_cfg)
+        m.classifier = nn.Linear(m.classifier.in_features, 5)   # OrientationNet does this
+        raw = torch.load(ckpt, map_location="cpu", weights_only=False)
+        st = raw.get("state", raw) if isinstance(raw, dict) and "state" in raw else raw
+        m.load_state_dict(OrderedDict((k.replace("module.","").replace("model.",""), v)
+                                      for k, v in st.items()), strict=True)
+        m.eval(); self.m = m
+        self.imsize = tuple(_cfg.MODEL.IMSIZE)
+        self.hflip, self.vflip = _cfg.TEST.HFLIP, _cfg.TEST.VFLIP
+
+    def theta(self, image_bytes, bbox):
+        # --- AnimalWbiaDataset.__getitem__ ---
+        image = imageio.imread(io.BytesIO(image_bytes))
+        x1, y1, w, h = bbox
+        crop = image[y1:y1+h, x1:x1+w]
+        if min(crop.shape) < 1:                       # animal_wbia.py:25-28
+            crop = image
+        crop = sk_resize(crop, self.imsize, order=3, anti_aliasing=True)
+        x = _T(crop).unsqueeze(0).float()             # _plugin.py:272 .float()
+        # --- OrientationNet.forward ---
+        with torch.no_grad():
+            out = torch.sigmoid(self.m(x))
+            if self.hflip:
+                oh = torch.sigmoid(self.m(torch.flip(x, [3]))).numpy()
+                oh = _utils.hflip_back(oh, [1.0, 1.0]); oh = torch.from_numpy(oh.copy())
+            if self.vflip:
+                ov = torch.sigmoid(self.m(torch.flip(x, [2]))).numpy()
+                ov = _utils.vflip_back(ov, [1.0, 1.0]); ov = torch.from_numpy(ov.copy())
+            if self.hflip and self.vflip:
+                out = (out + oh + ov) / 3
+        coords = out.numpy()
+        return float(_eval.compute_theta(coords)[0]), coords[0].tolist()

--- a/scripts/preflight/run_gate.py
+++ b/scripts/preflight/run_gate.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""wbia-orientation fidelity gate — release-blocking host preflight.
+
+Executes the pinned REFERENCE and the PORT live on the same bytes and compares
+them to each other. There are no frozen expected values: they would pin one
+implementation's output and rot on any dependency bump. See README.md.
+
+Exit 0 = pass. Non-zero = do not deploy.
+"""
+import argparse, hashlib, json, math, os, sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def circular_error(a: float, b: float) -> float:
+    d = a - b
+    return abs(math.atan2(math.sin(d), math.cos(d)))
+
+
+def environment() -> dict:
+    import numpy, torch, timm, skimage, imageio, PIL
+    return {"torch": torch.__version__, "timm": timm.__version__,
+            "numpy": numpy.__version__, "scikit-image": skimage.__version__,
+            "imageio": imageio.__version__, "pillow": PIL.__version__}
+
+
+def sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--fixtures", required=True, help="directory of fixture images")
+    ap.add_argument("--artifact", default="preflight-artifact.json")
+    args = ap.parse_args()
+
+    from reference_runner import Reference
+    from app.models.wbia_orientation import WbiaOrientationModel
+
+    manifest = json.load(open(args.manifest))
+    thr = manifest["thresholds"]
+    env = environment()
+    print(f"environment: {env}")
+
+    rows, failures = [], []
+    for ck in manifest["checkpoints"]:
+        path = ck["path"]
+        if not os.path.isfile(path):
+            failures.append(f"checkpoint missing: {path}")
+            continue
+        digest = sha256(path)
+        print(f"\n{ck['model_id']}  sha256={digest[:16]}...")
+        ref = Reference(path)
+        port = WbiaOrientationModel()
+        port.load(model_id=ck["model_id"], checkpoint_path=path, device="cpu")
+
+        for fx in manifest["fixtures"]:
+            img = os.path.join(args.fixtures, fx.get("file", ""))
+            if not os.path.isfile(img):
+                failures.append(f"fixture missing: {img}")
+                continue
+            data = open(img, "rb").read()
+            got = hashlib.sha256(data).hexdigest()
+            if fx.get("sha256") not in (None, "", "<fixture byte hash>") and got != fx["sha256"]:
+                failures.append(f"fixture {img} hash mismatch (manifest identity broken)")
+                continue
+            t_ref, c_ref = ref.theta(data, fx["bbox"])
+            r = port.predict_batch(data, [fx["bbox"]])[0]
+            e_t = circular_error(t_ref, r["theta"])
+            e_c = max(abs(a - b) for a, b in zip(c_ref, r["coords_normalized"]))
+            rows.append({"checkpoint": ck["model_id"], "fixture": fx.get("file"),
+                         "stratum": fx.get("stratum"), "bbox": fx["bbox"],
+                         "theta_ref": t_ref, "theta_port": r["theta"],
+                         "theta_err": e_t, "coord_err": e_c,
+                         "effective_bbox": r["effective_bbox"]})
+            if e_t > thr["theta_circular_max_rad"]:
+                failures.append(f"{ck['model_id']}/{fx.get('file')}: theta err {e_t:.3e}")
+            if e_c > thr["coords_elementwise_max"]:
+                failures.append(f"{ck['model_id']}/{fx.get('file')}: coord err {e_c:.3e}")
+
+    # Enforce per-stratum minimums: a gate that silently ran 3 samples is not a gate.
+    for name, spec in manifest.get("strata", {}).items():
+        if name.startswith("_"):
+            continue
+        n = sum(1 for r in rows if r["stratum"] == name)
+        if n < spec.get("min_samples", 0):
+            failures.append(f"stratum '{name}': {n} samples < required {spec['min_samples']}")
+
+    if rows:
+        print(f"\nworst theta err: {max(r['theta_err'] for r in rows):.3e} "
+              f"(<= {thr['theta_circular_max_rad']:.0e})")
+        print(f"worst coord err: {max(r['coord_err'] for r in rows):.3e} "
+              f"(<= {thr['coords_elementwise_max']:.0e})")
+
+    json.dump({"environment": env, "results": rows, "failures": failures},
+              open(args.artifact, "w"), indent=2)
+    print(f"artifact -> {args.artifact}")
+
+    if failures:
+        print("\n*** GATE FAILED — DO NOT DEPLOY ***")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("\nGATE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pipeline_router_theta.py
+++ b/tests/test_pipeline_router_theta.py
@@ -233,3 +233,72 @@ def test_unknown_orientation_model_type_is_rejected():
     om = MagicMock(spec=MiewidModel)              # not an orientation model at all
     r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
     assert r.status_code == 400
+
+
+# --------------------------------- request-level validation (review round 2)
+
+def test_malformed_second_result_stops_consumers_for_the_first_bbox_too():
+    """Checking only the COUNT and dereferencing rows lazily inside the loop would
+    let bbox 0 run classify/extract before bbox 1's bad row failed the request.
+    Request-level fail-closed must mean NO consumer runs."""
+    pm, cm, em = _models(n_bboxes=2)
+    om = _orientation([0.1, 0.2])
+    om.predict_batch.return_value = [
+        {"model_id": "o", "theta": 0.1, "coords_normalized": [0.5] * 5,
+         "effective_bbox": [10, 10, 50, 50]},
+        {"model_id": "o", "theta": float("nan"), "coords_normalized": [0.5] * 5,
+         "effective_bbox": [20, 20, 50, 50]},        # malformed row 2
+    ]
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 500
+    cm.predict.assert_not_called()
+    em.extract_embeddings.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_row", [
+    {"model_id": "o", "coords_normalized": [0.5] * 5, "effective_bbox": [1, 1, 2, 2]},   # no theta
+    {"model_id": "o", "theta": "x", "coords_normalized": [0.5] * 5, "effective_bbox": [1, 1, 2, 2]},
+    {"model_id": "o", "theta": 0.1, "coords_normalized": [0.5] * 5},                     # no effective_bbox
+    {"model_id": "o", "theta": 0.1, "coords_normalized": [0.5] * 5, "effective_bbox": [1, 1]},
+    {"model_id": "o", "theta": 0.1, "coords_normalized": [0.5] * 5, "effective_bbox": [1.5, 1, 2, 2]},
+    "not-an-object",
+])
+def test_malformed_orientation_rows_fail_the_request(bad_row):
+    pm, cm, em = _models()
+    om = _orientation([0.1])
+    om.predict_batch.return_value = [bad_row]
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 500
+    cm.predict.assert_not_called()
+
+
+def test_detector_bbox_is_retained_as_an_audit_field():
+    """effective_bbox becomes the persisted bbox, so what the detector actually
+    said must stay recoverable."""
+    pm, cm, em = _models()
+    om = _orientation([0.5], [[0, 0, 640, 480]])
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    res = r.json()["results"][0]
+    assert res["bbox"] == [0, 0, 640, 480]          # what theta describes
+    assert res["detector_bbox"] == [10, 10, 50, 50]  # what the detector proposed
+
+
+def test_fractional_degenerate_bbox_is_skipped_on_the_non_regressor_path():
+    """width=0.5 passes `width <= 0` but int(0.5) == 0 — consumers would have got
+    a degenerate box. The guard must run AFTER integerization."""
+    from app.models.densenet_classifier import DenseNetClassifierModel
+    from app.models.miewid import MiewidModel
+    from app.models.yolo_ultralytics import YOLOUltralyticsModel
+    pm = MagicMock(spec=YOLOUltralyticsModel)
+    pm.predict.return_value = {"predictions": [
+        {"bbox": [10, 10, 0.5, 50], "theta": 0.0, "score": 0.9,
+         "class": "x", "class_id": 0}]}
+    cm = MagicMock(spec=DenseNetClassifierModel)
+    cm.predict.return_value = {"predictions": []}
+    em = MagicMock(spec=MiewidModel)
+    em.extract_embeddings.return_value = np.zeros((1, 2152))
+    r = _client(pm, cm, em).post("/pipeline/", json=_payload())
+    assert r.status_code == 200, r.text
+    assert r.json()["results"] == []
+    cm.predict.assert_not_called()

--- a/tests/test_pipeline_router_theta.py
+++ b/tests/test_pipeline_router_theta.py
@@ -1,0 +1,235 @@
+"""Integration tests for the wbia-orientation theta path through /pipeline/.
+
+Whale sharks lost rotation in June 2026 because theta came only from the
+detector, and whaleshark_v0 is a lightnet model that never emits it — so theta
+defaulted to 0.0 and MiewID embedded tilted animals. These tests pin the wiring
+that repairs it, and specifically the properties whose absence would recreate the
+bug in a new place:
+
+  - theta comes from the regressor, NOT the detector's 0.0
+  - orientation runs BEFORE classify/extract (theta must precede the crop)
+  - a failure is REQUEST-level: 500, no results, consumers never invoked
+  - effective_bbox reaches classify, extract, AND the emitted (persisted) bbox
+"""
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import pipeline_router
+
+
+def _client(predict_model, classify_model, extract_model, orientation_model=None):
+    app = FastAPI()
+    app.include_router(pipeline_router.router)
+    handler = MagicMock()
+    handler.get_model.side_effect = lambda mid: {
+        "p": predict_model, "c": classify_model, "e": extract_model,
+        "o": orientation_model,
+    }.get(mid)
+    handler.get_model_info.side_effect = lambda mid: {
+        "p": {"config": {}}, "c": {"config": {}},
+        "e": {"config": {"version": 4.1}}, "o": {"config": {}},
+    }.get(mid)
+    handler.list_models.return_value = {"p": {}, "c": {}, "e": {}, "o": {}}
+    app.state.model_handler = handler
+    return TestClient(app)
+
+
+def _models(n_bboxes=1):
+    from app.models.densenet_classifier import DenseNetClassifierModel
+    from app.models.miewid import MiewidModel
+    from app.models.yolo_ultralytics import YOLOUltralyticsModel
+
+    pm = MagicMock(spec=YOLOUltralyticsModel)
+    pm.predict.return_value = {"predictions": [
+        {"bbox": [10 * k, 10 * k, 50, 50], "theta": 0.0, "score": 0.9,
+         "class": "whaleshark", "class_id": 0}
+        for k in range(1, n_bboxes + 1)
+    ]}
+    cm = MagicMock(spec=DenseNetClassifierModel)
+    cm.predict.return_value = {"predictions": [
+        {"label": "whaleshark:left", "probability": 0.9, "index": 0,
+         "species": "whaleshark", "viewpoint": "left"}]}
+    em = MagicMock(spec=MiewidModel)
+    em.extract_embeddings.return_value = np.zeros((1, 2152))
+    return pm, cm, em
+
+
+def _orientation(thetas, effective_bboxes=None):
+    from app.models.wbia_orientation import WbiaOrientationModel
+    om = MagicMock(spec=WbiaOrientationModel)
+    effs = effective_bboxes or [[10, 10, 50, 50]] * len(thetas)
+    om.predict_batch.return_value = [
+        {"model_id": "o", "theta": t, "coords_normalized": [0.5] * 5,
+         "effective_bbox": e}
+        for t, e in zip(thetas, effs)
+    ]
+    return om
+
+
+PAYLOAD = {"image_uri": "data:image/png;base64,iVBORw0KGgo=",
+           "predict_model_id": "p", "classify_model_id": "c",
+           "extract_model_id": "e"}
+
+
+def _payload(**kw):
+    return {**PAYLOAD, **kw}
+
+
+# The data URI below is decoded by resolve_image_uri but never really rendered:
+# every model here is mocked, so the bytes only need to travel. Same convention as
+# tests/test_pipeline_router_classifier.py.
+
+
+# ------------------------------------------------------------------ happy path
+
+def test_theta_comes_from_the_regressor_not_the_detector():
+    """The whole point: lightnet reports theta=0.0, the regressor reports the
+    real angle, and the regressor must win."""
+    pm, cm, em = _models()
+    om = _orientation([1.234])
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    res = r.json()["results"][0]
+    assert res["theta"] == pytest.approx(1.234)      # detector said 0.0
+    assert res["theta_source"] == "orientation"
+
+
+def test_theta_source_says_detector_when_no_orientation_configured():
+    pm, cm, em = _models()
+    r = _client(pm, cm, em).post("/pipeline/", json=_payload())
+    assert r.status_code == 200, r.text
+    assert r.json()["results"][0]["theta_source"] == "detector"
+
+
+def test_orientation_runs_before_classify_and_extract():
+    """theta must be known before the crop is embedded, so orientation cannot sit
+    in the parallel gather with its consumers."""
+    pm, cm, em = _models()
+    om = _orientation([0.5])
+    order = []
+    om.predict_batch.side_effect = lambda **kw: (
+        order.append("orientation"),
+        [{"model_id": "o", "theta": 0.5, "coords_normalized": [0.5] * 5,
+          "effective_bbox": [10, 10, 50, 50]}])[1]
+    cm.predict.side_effect = lambda **kw: (order.append("classify"), {"predictions": []})[1]
+    em.extract_embeddings.side_effect = lambda **kw: (
+        order.append("extract"), np.zeros((1, 2152)))[1]
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    assert order[0] == "orientation", f"orientation must run first, got {order}"
+
+
+def test_orientation_is_batched_once_for_all_bboxes():
+    """One predict_batch per image (3 TTA forwards), not one call per bbox."""
+    pm, cm, em = _models(n_bboxes=3)
+    om = _orientation([0.1, 0.2, 0.3],
+                      [[10, 10, 50, 50], [20, 20, 50, 50], [30, 30, 50, 50]])
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    assert om.predict_batch.call_count == 1
+    assert [x["theta"] for x in r.json()["results"]] == pytest.approx([0.1, 0.2, 0.3])
+
+
+# ----------------------------------------------------------- effective_bbox
+
+def test_effective_bbox_is_emitted_as_the_persisted_bbox():
+    """Wildbook persists the result's bbox alongside theta
+    (MlServiceProcessor.featureParams). Emitting the detector's original while
+    theta describes effective_bbox would STORE a theta/region mismatch."""
+    pm, cm, em = _models()
+    om = _orientation([0.5], [[0, 0, 640, 480]])     # e.g. degenerate -> full frame
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    assert r.json()["results"][0]["bbox"] == [0, 0, 640, 480]   # not [10,10,50,50]
+
+
+def test_effective_bbox_is_what_classify_and_extract_receive():
+    """All three consumers must see the identical region."""
+    pm, cm, em = _models()
+    om = _orientation([0.5], [[0, 0, 640, 480]])
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    assert cm.predict.call_args.kwargs["bbox"] == [0, 0, 640, 480]
+    assert list(em.extract_embeddings.call_args.kwargs["bbox"]) == [0, 0, 640, 480]
+
+
+def test_orientation_theta_is_passed_to_classify_and_extract():
+    pm, cm, em = _models()
+    om = _orientation([1.234])
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    assert cm.predict.call_args.kwargs["theta"] == pytest.approx(1.234)
+    assert em.extract_embeddings.call_args.kwargs["theta"] == pytest.approx(1.234)
+
+
+# --------------------------------------------------------------- fail-closed
+
+def test_orientation_failure_fails_the_whole_request():
+    """A soft-fail here would fall back to the detector's 0.0 and embed an
+    unrotated crop — the exact regression being repaired."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    pm, cm, em = _models()
+    om = _orientation([0.5])
+    om.predict_batch.side_effect = OrientationInferenceError("non-finite theta")
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 500
+    assert "theta" in r.text.lower()
+
+
+def test_orientation_failure_means_classify_and_extract_never_run():
+    from app.models.wbia_orientation import OrientationInferenceError
+    pm, cm, em = _models()
+    om = _orientation([0.5])
+    om.predict_batch.side_effect = OrientationInferenceError("boom")
+    _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    cm.predict.assert_not_called()
+    em.extract_embeddings.assert_not_called()
+
+
+def test_one_bad_bbox_fails_the_whole_request_not_just_that_bbox():
+    """Partial success would silently drop a detection; a 5xx body cannot carry
+    successful siblings anyway."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    pm, cm, em = _models(n_bboxes=2)
+    om = _orientation([0.1, 0.2])
+    om.predict_batch.side_effect = OrientationInferenceError("bbox 1 is NaN")
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 500
+    assert r.json().get("results") is None
+
+
+def test_misaligned_orientation_result_count_fails_the_request():
+    """A short/long list would attach one bbox's theta to another's crop."""
+    pm, cm, em = _models(n_bboxes=3)
+    om = _orientation([0.1])          # 1 result for 3 bboxes
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 500
+    assert "1 result" in r.text or "result(s)" in r.text
+
+
+# ------------------------------------------------------- legacy label path
+
+def test_densenet_orientation_label_path_still_works():
+    """The legacy viewpoint-label orientation type must keep functioning."""
+    from app.models.densenet_orientation import DenseNetOrientationModel
+    pm, cm, em = _models()
+    om = MagicMock(spec=DenseNetOrientationModel)
+    om.predict.return_value = {"predictions": [
+        {"label": "left", "probability": 0.9, "index": 0}]}
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 200, r.text
+    res = r.json()["results"][0]
+    assert res["theta_source"] == "detector"      # a label model supplies no theta
+    assert res["orientation"]["label"] == "left"
+
+
+def test_unknown_orientation_model_type_is_rejected():
+    from app.models.miewid import MiewidModel
+    pm, cm, em = _models()
+    om = MagicMock(spec=MiewidModel)              # not an orientation model at all
+    r = _client(pm, cm, em, om).post("/pipeline/", json=_payload(orientation_model_id="o"))
+    assert r.status_code == 400

--- a/tests/test_wbia_orientation.py
+++ b/tests/test_wbia_orientation.py
@@ -1,0 +1,337 @@
+"""Tests for WbiaOrientationModel — the wbia-plugin-orientation theta port.
+
+This port's failure mode is being SILENTLY wrong by an angle, which downstream is
+indistinguishable from correct output — the same class of bug as issue #33. So
+these tests pin the reference algorithm's arithmetic exactly, plus every failure
+mode surfaced in design review:
+
+  - fail-closed (a 0.0 fallback IS the bug being repaired; 0.0 is also valid)
+  - NumPy's non-clamping slice (a wide negative bbox crops the FAR EDGE)
+  - integerization rule (int(-0.5)==0 vs floor(-0.5)==-1 -> far edge)
+  - no label/probability ever emitted (the #33 confusion)
+  - predict_batch ordering (a misaligned result attaches theta to the wrong crop)
+
+Reference: wbia-plugin-orientation. Real-weight fidelity vs the reference runs in
+the host preflight, not here — the checkpoints are hundreds of MB.
+"""
+import io
+import math
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+
+def _png(arr: np.ndarray) -> bytes:
+    buf = io.BytesIO()
+    Image.fromarray(arr.astype(np.uint8)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+RGB = _png(np.random.RandomState(0).randint(0, 255, (300, 400, 3), dtype=np.uint8))
+
+
+def _model(coords=(0.5, 0.5, 1.0, 0.5, 0.1), hflip=False, vflip=False):
+    """A loaded model whose backbone returns fixed pre-sigmoid logits."""
+    from app.models.wbia_orientation import WbiaOrientationModel
+    m = WbiaOrientationModel()
+    m.model_id, m.device, m.imsize = "t", "cpu", (224, 224)
+    m.hflip, m.vflip = hflip, vflip
+    # logit(p) so sigmoid(logit(p)) == p, letting tests state coords directly.
+    # Clamped off the open interval's ends: logit(0)/logit(1) are +-inf.
+    def _logit(c, eps=1e-9):
+        c = min(max(c, eps), 1 - eps)
+        return math.log(c / (1 - c))
+    logits = torch.tensor([[_logit(c) for c in coords]])
+    m.model = MagicMock(return_value=logits)
+    return m
+
+
+# ---------------------------------------------------------------- theta math
+
+def test_compute_theta_matches_reference_formula():
+    """core/evaluate.py:9-20 — arctan2(yt-yc, xt-xc) + radians(90)."""
+    from app.models.wbia_orientation import compute_theta
+    # xt-xc = 0.5, yt-yc = 0 -> arctan2(0, 0.5) = 0, +90deg
+    assert compute_theta([0.5, 0.5, 1.0, 0.5, 0.1]) == pytest.approx(math.radians(90))
+
+
+@pytest.mark.parametrize("coords,expected_deg", [
+    ([0.5, 0.5, 1.0, 0.5, 0.1], 90.0),    # tip east   -> 90
+    ([0.5, 0.5, 0.5, 1.0, 0.1], 180.0),   # tip south  -> 180
+    ([0.5, 0.5, 0.0, 0.5, 0.1], 270.0),   # tip west   -> 270
+    ([0.5, 0.5, 0.5, 0.0, 0.1], 0.0),     # tip north  -> 0
+])
+def test_compute_theta_cardinals(coords, expected_deg):
+    from app.models.wbia_orientation import compute_theta
+    got = math.degrees(compute_theta(coords))
+    assert math.cos(math.radians(got - expected_deg)) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_the_plus_90_degrees_is_not_dropped():
+    """Without the +90 this returns 0 — a silent, plausible, wrong angle."""
+    from app.models.wbia_orientation import compute_theta
+    assert compute_theta([0.5, 0.5, 1.0, 0.5, 0.1]) != pytest.approx(0.0)
+
+
+# ------------------------------------------------- bbox resolution (Critical)
+
+@pytest.mark.parametrize("bbox,expected", [
+    ([10, 10, 50, 50], [10, 10, 50, 50]),        # ordinary
+    ([-20, 10, 50, 50], [380, 10, 0, 50]),       # narrow negative -> empty
+    ([-20, 10, 500, 50], [380, 10, 20, 50]),     # WIDE negative -> FAR EDGE
+    ([380, 10, 50, 50], [380, 10, 20, 50]),      # overrun -> truncated
+    ([500, 400, 50, 50], [400, 300, 0, 0]),      # fully outside -> empty
+])
+def test_resolve_bbox_reproduces_numpy_slicing(bbox, expected):
+    """NumPy slicing does NOT clamp: a negative origin resolves from the far
+    edge. resolve_bbox must reproduce exactly what the reference's raw slice did,
+    or theta describes a region the detector never pointed at."""
+    from app.models.wbia_orientation import resolve_bbox
+    assert resolve_bbox(bbox, width=400, height=300) == expected
+
+
+def test_resolve_bbox_agrees_with_actual_numpy_slice():
+    """Ground the rule against NumPy itself rather than our belief about it."""
+    from app.models.wbia_orientation import resolve_bbox
+    img = np.zeros((300, 400, 3))
+    for bbox in ([10, 10, 50, 50], [-20, 10, 500, 50], [380, 10, 50, 50],
+                 [500, 400, 50, 50], [-20, 10, 50, 50]):
+        x, y, w, h = bbox
+        actual = img[y:y + h, x:x + w]
+        eff = resolve_bbox(bbox, 400, 300)
+        assert (eff[2], eff[3]) == (actual.shape[1], actual.shape[0]), bbox
+
+
+def test_wide_negative_bbox_really_does_hit_the_far_edge():
+    """Documents WHY resolve_bbox exists: the crop is real, and wrong."""
+    img = np.zeros((300, 400, 3))
+    img[:, 380:400] = 1.0                       # mark the far-right edge
+    assert img[0:300, -20:480].sum() > 0        # a "left" bbox crops the RIGHT edge
+
+
+@pytest.mark.parametrize("bad", [
+    [float("nan"), 0, 10, 10],
+    [0, float("inf"), 10, 10],
+    [None, 0, 10, 10],
+])
+def test_resolve_bbox_rejects_non_finite(bad):
+    from app.models.wbia_orientation import resolve_bbox, OrientationInferenceError
+    with pytest.raises(OrientationInferenceError, match="non-finite|non-numeric"):
+        resolve_bbox(bad, 400, 300)
+
+
+def test_resolve_bbox_rejects_wrong_arity():
+    from app.models.wbia_orientation import resolve_bbox, OrientationInferenceError
+    with pytest.raises(OrientationInferenceError, match=r"\[x, y, w, h\]"):
+        resolve_bbox([1, 2, 3], 400, 300)
+
+
+@pytest.mark.parametrize("bbox,expected_x", [
+    ([-0.5, 10, 50, 50], 0),      # int(-0.5) == 0   (truncate toward zero)
+    ([10.9, 10, 50, 50], 10),     # int(10.9) == 10
+    ([-1.9, 10, 50, 50], -1),     # int(-1.9) == -1
+])
+def test_integerization_truncates_toward_zero(bbox, expected_x):
+    """int(), matching pipeline_router:218. floor(-0.5) would give -1, which then
+    resolves from the far edge — the rule choice is load-bearing."""
+    from app.models.wbia_orientation import resolve_bbox
+    eff = resolve_bbox(bbox, 400, 300)
+    assert eff[0] == (expected_x if expected_x >= 0 else 400 + expected_x)
+
+
+# ------------------------------------------------------------ TTA arithmetic
+
+def test_tta_hflip_mirrors_only_x_coords():
+    """utils.py:88-102 with image_h_w=[1.0,1.0]: indices 0 and 2 -> 1-x."""
+    m = _model(coords=(0.25, 0.4, 0.75, 0.6, 0.1), hflip=True, vflip=False)
+    out = m._forward_tta(torch.zeros(1, 3, 224, 224))[0].tolist()
+    # mean of original and its x-mirrored self: x-coords -> 0.5, others unchanged
+    assert out[0] == pytest.approx((0.25 + 0.75) / 2)
+    assert out[2] == pytest.approx((0.75 + 0.25) / 2)
+    assert out[1] == pytest.approx(0.4)
+    assert out[3] == pytest.approx(0.6)
+
+
+def test_tta_vflip_mirrors_only_y_coords():
+    """utils.py:104-116: indices 1 and 3 -> 1-y."""
+    m = _model(coords=(0.25, 0.4, 0.75, 0.6, 0.1), hflip=False, vflip=True)
+    out = m._forward_tta(torch.zeros(1, 3, 224, 224))[0].tolist()
+    assert out[1] == pytest.approx((0.4 + 0.6) / 2)
+    assert out[3] == pytest.approx((0.6 + 0.4) / 2)
+    assert out[0] == pytest.approx(0.25)
+    assert out[2] == pytest.approx(0.75)
+
+
+def test_tta_is_a_three_way_mean_when_both_flips_on():
+    """orientation_net.py:93 — (out + out_h + out_v) / 3, the deployed default."""
+    m = _model(coords=(0.25, 0.4, 0.75, 0.6, 0.1), hflip=True, vflip=True)
+    out = m._forward_tta(torch.zeros(1, 3, 224, 224))[0].tolist()
+    assert out[0] == pytest.approx((0.25 + 0.75 + 0.25) / 3)   # h mirrors x only
+    assert out[1] == pytest.approx((0.40 + 0.40 + 0.60) / 3)   # v mirrors y only
+    assert out[4] == pytest.approx(0.1)                         # w never mirrors
+
+
+def test_tta_disabled_is_a_single_forward():
+    m = _model(coords=(0.25, 0.4, 0.75, 0.6, 0.1))
+    m.model.reset_mock()
+    m._forward_tta(torch.zeros(1, 3, 224, 224))
+    assert m.model.call_count == 1
+
+
+def test_head_is_sigmoid_not_softmax():
+    """Softmaxing these coords is issue #33: it yields ~0.2 pseudo-probabilities.
+    Sigmoid is why they are independent values in [0,1] — and they need not sum
+    to 1, which softmax would force."""
+    m = _model(coords=(0.9, 0.9, 0.9, 0.9, 0.9))
+    out = m._forward_tta(torch.zeros(1, 3, 224, 224))[0]
+    assert out.sum().item() == pytest.approx(4.5, abs=1e-4)
+    assert all(0.0 <= v <= 1.0 for v in out.tolist())
+
+
+# ----------------------------------------------------------- output contract
+
+def test_predict_returns_theta_and_never_a_label():
+    """The #33 failure mode: any label/probability could be mistaken downstream
+    for a viewpoint classification."""
+    m = _model()
+    r = m.predict_batch(RGB, [[10, 10, 100, 100]])[0]
+    assert set(r) == {"model_id", "theta", "coords_normalized", "effective_bbox"}
+    for forbidden in ("label", "probability", "class_id", "class", "predictions"):
+        assert forbidden not in r
+    assert math.isfinite(r["theta"])
+    assert len(r["coords_normalized"]) == 5
+
+
+def test_predict_batch_is_ordered_one_per_bbox():
+    """A misaligned result would attach one bbox's theta to another's crop."""
+    m = _model()
+    bboxes = [[10, 10, 100, 100], [50, 50, 60, 60], [0, 0, 400, 300]]
+    out = m.predict_batch(RGB, bboxes)
+    assert len(out) == len(bboxes)
+    for r, b in zip(out, bboxes):
+        assert r["effective_bbox"] == [b[0], b[1], b[2], b[3]]
+
+
+def test_degenerate_bbox_falls_back_to_full_frame_in_effective_bbox():
+    """animal_wbia.py:25-28 reloads the full image; effective_bbox must SAY so,
+    or classify/extract crop a different region than theta describes."""
+    m = _model()
+    r = m.predict_batch(RGB, [[500, 400, 10, 10]])[0]     # fully outside
+    assert r["effective_bbox"] == [0, 0, 400, 300]
+
+
+def test_none_bbox_means_full_frame():
+    m = _model()
+    assert m.predict_batch(RGB, [None])[0]["effective_bbox"] == [0, 0, 400, 300]
+
+
+# --------------------------------------------------------------- fail-closed
+
+def test_non_finite_theta_raises_rather_than_defaulting_to_zero():
+    """A 0.0 fallback IS the bug being repaired — and 0.0 is also a legitimate
+    prediction, so a sentinel could not be told apart from a real answer."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    m = _model()
+    m.model = MagicMock(return_value=torch.tensor([[float("nan")] * 5]))
+    with pytest.raises(OrientationInferenceError, match="non-finite theta"):
+        m.predict_batch(RGB, [[10, 10, 100, 100]])
+
+
+def test_predicted_zero_theta_is_valid_not_an_error():
+    """The converse: 0.0 must pass through."""
+    m = _model(coords=(0.5, 0.5, 0.5, 0.0, 0.1))   # tip north -> theta 0
+    r = m.predict_batch(RGB, [[10, 10, 100, 100]])[0]
+    assert math.cos(r["theta"]) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_predict_rejects_a_pre_rotated_crop():
+    """The reference consumes the axis-aligned bbox and derives theta itself;
+    a detector-rotated crop would double-rotate."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    m = _model()
+    with pytest.raises(OrientationInferenceError, match="pre-rotated|axis-aligned"):
+        m.predict(RGB, bbox=[10, 10, 100, 100], theta=0.5)
+
+
+def test_unloaded_model_raises():
+    from app.models.wbia_orientation import WbiaOrientationModel, OrientationInferenceError
+    with pytest.raises(OrientationInferenceError, match="not loaded"):
+        WbiaOrientationModel().predict_batch(RGB, [None])
+
+
+def test_undecodable_bytes_raise():
+    from app.models.wbia_orientation import OrientationInferenceError
+    m = _model()
+    with pytest.raises(OrientationInferenceError, match="could not decode"):
+        m.predict_batch(b"not an image", [None])
+
+
+# ------------------------------------------------- RGB canonicalization
+
+def test_rgb_input_passes_through_untouched():
+    """Fidelity depends on (H,W,3) reaching the model exactly as the reference
+    would feed it."""
+    from app.models.wbia_orientation import _canonicalize_rgb
+    arr = np.random.rand(10, 12, 3)
+    assert _canonicalize_rgb(arr) is arr
+
+
+def test_grayscale_is_replicated_to_three_channels():
+    """Deliberate deviation: the reference RAISES here (Normalize expects 3ch)."""
+    from app.models.wbia_orientation import _canonicalize_rgb
+    out = _canonicalize_rgb(np.random.rand(10, 12))
+    assert out.shape == (10, 12, 3)
+    assert np.array_equal(out[:, :, 0], out[:, :, 2])
+
+
+def test_rgba_alpha_is_dropped():
+    from app.models.wbia_orientation import _canonicalize_rgb
+    assert _canonicalize_rgb(np.random.rand(10, 12, 4)).shape == (10, 12, 3)
+
+
+def test_unsupported_channel_count_raises():
+    from app.models.wbia_orientation import _canonicalize_rgb, OrientationInferenceError
+    with pytest.raises(OrientationInferenceError, match="Unsupported image shape"):
+        _canonicalize_rgb(np.random.rand(10, 12, 7))
+
+
+def test_grayscale_image_end_to_end():
+    m = _model()
+    gray = _png(np.random.RandomState(1).randint(0, 255, (300, 400), dtype=np.uint8))
+    assert math.isfinite(m.predict_batch(gray, [[10, 10, 100, 100]])[0]["theta"])
+
+
+# ----------------------------------------------------------------- loading
+
+def test_registered_in_model_registry():
+    from app.models.model_handler import MODEL_REGISTRY
+    assert MODEL_REGISTRY["wbia-orientation"]["class"] == "WbiaOrientationModel"
+
+
+def test_load_rejects_unknown_config_keys():
+    from app.models.wbia_orientation import WbiaOrientationModel
+    with pytest.raises(ValueError, match="unknown config key"):
+        WbiaOrientationModel().load(model_id="t", checkpoint_path="/x", label_map={0: "a"})
+
+
+def test_load_requires_a_checkpoint():
+    from app.models.wbia_orientation import WbiaOrientationModel
+    with pytest.raises(ValueError, match="checkpoint_path is required"):
+        WbiaOrientationModel().load(model_id="t")
+
+
+def test_load_uses_strict_state_dict():
+    """A mismatched checkpoint must fail loudly, not silently mispredict."""
+    from app.models.wbia_orientation import WbiaOrientationModel
+    with patch("torch.load", return_value={"classifier.weight": torch.zeros(5, 2048)}), \
+         patch("app.models.wbia_orientation.get_checkpoint_path", side_effect=lambda p: p), \
+         patch("timm.create_model") as tm:
+        backbone = MagicMock()
+        backbone.load_state_dict.side_effect = RuntimeError("size mismatch")
+        tm.return_value = backbone
+        with pytest.raises(RuntimeError, match="size mismatch"):
+            WbiaOrientationModel().load(model_id="t", checkpoint_path="/x")
+        assert backbone.load_state_dict.call_args.kwargs.get("strict") is True

--- a/tests/test_wbia_orientation.py
+++ b/tests/test_wbia_orientation.py
@@ -45,7 +45,9 @@ def _model(coords=(0.5, 0.5, 1.0, 0.5, 0.1), hflip=False, vflip=False):
         c = min(max(c, eps), 1 - eps)
         return math.log(c / (1 - c))
     logits = torch.tensor([[_logit(c) for c in coords]])
-    m.model = MagicMock(return_value=logits)
+    # Size the output to the incoming batch: predict_batch stacks all crops into
+    # ONE tensor, so a fixed (1,5) would fail the shape contract.
+    m.model = MagicMock(side_effect=lambda x, *a, **k: logits.repeat(x.shape[0], 1))
     return m
 
 
@@ -223,9 +225,16 @@ def test_degenerate_bbox_falls_back_to_full_frame_in_effective_bbox():
     assert r["effective_bbox"] == [0, 0, 400, 300]
 
 
-def test_none_bbox_means_full_frame():
+def test_none_bbox_is_rejected_not_defaulted_to_full_frame():
+    """Defaulting a missing bbox to the full frame would silently change the
+    region theta describes — the same class of safe-looking default this model
+    type exists to remove."""
+    from app.models.wbia_orientation import OrientationInferenceError
     m = _model()
-    assert m.predict_batch(RGB, [None])[0]["effective_bbox"] == [0, 0, 400, 300]
+    with pytest.raises(OrientationInferenceError, match="bbox is required"):
+        m.predict_batch(RGB, [None])
+    with pytest.raises(OrientationInferenceError, match="bbox is required"):
+        m.predict(RGB)
 
 
 # --------------------------------------------------------------- fail-closed
@@ -235,8 +244,9 @@ def test_non_finite_theta_raises_rather_than_defaulting_to_zero():
     prediction, so a sentinel could not be told apart from a real answer."""
     from app.models.wbia_orientation import OrientationInferenceError
     m = _model()
-    m.model = MagicMock(return_value=torch.tensor([[float("nan")] * 5]))
-    with pytest.raises(OrientationInferenceError, match="non-finite theta"):
+    m.model = MagicMock(side_effect=lambda x, *a, **k:
+                        torch.tensor([[float("nan")] * 5]).repeat(x.shape[0], 1))
+    with pytest.raises(OrientationInferenceError, match="non-finite"):
         m.predict_batch(RGB, [[10, 10, 100, 100]])
 
 
@@ -259,14 +269,14 @@ def test_predict_rejects_a_pre_rotated_crop():
 def test_unloaded_model_raises():
     from app.models.wbia_orientation import WbiaOrientationModel, OrientationInferenceError
     with pytest.raises(OrientationInferenceError, match="not loaded"):
-        WbiaOrientationModel().predict_batch(RGB, [None])
+        WbiaOrientationModel().predict_batch(RGB, [[0, 0, 10, 10]])
 
 
 def test_undecodable_bytes_raise():
     from app.models.wbia_orientation import OrientationInferenceError
     m = _model()
     with pytest.raises(OrientationInferenceError, match="could not decode"):
-        m.predict_batch(b"not an image", [None])
+        m.predict_batch(b"not an image", [[0, 0, 10, 10]])
 
 
 # ------------------------------------------------- RGB canonicalization
@@ -304,6 +314,123 @@ def test_grayscale_image_end_to_end():
     assert math.isfinite(m.predict_batch(gray, [[10, 10, 100, 100]])[0]["theta"])
 
 
+# ------------------------------- coverage added after implementation review
+
+def test_nan_in_w_is_rejected_even_though_theta_stays_finite():
+    """theta reads indices 0-3, so a NaN in w (index 4) yields a FINITE theta and
+    would sail out inside coords_normalized. All five outputs must be checked."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    m = _model()
+    m.model = MagicMock(side_effect=lambda x, *a, **k:
+                        torch.tensor([[0.0, 0.0, 0.0, 0.0, float("nan")]]).repeat(x.shape[0], 1))
+    with pytest.raises(OrientationInferenceError, match="non-finite model output"):
+        m.predict_batch(RGB, [[10, 10, 100, 100]])
+
+
+@pytest.mark.parametrize("idx", [0, 1, 2, 3, 4])
+def test_non_finite_at_any_coord_index_is_rejected(idx):
+    """NaN, not inf: these are pre-sigmoid logits and sigmoid(inf) == 1.0, which
+    is perfectly finite. Only NaN propagates through the head."""
+    from app.models.wbia_orientation import OrientationInferenceError
+    m = _model()
+    vals = [0.0] * 5
+    vals[idx] = float("nan")
+    m.model = MagicMock(side_effect=lambda x, *a, **k:
+                        torch.tensor([vals]).repeat(x.shape[0], 1))
+    with pytest.raises(OrientationInferenceError, match="non-finite"):
+        m.predict_batch(RGB, [[10, 10, 100, 100]])
+
+
+def test_numpy_scalar_bboxes_are_accepted():
+    """Detectors hand us np.float32/np.int64 — Real, but not int/float instances."""
+    from app.models.wbia_orientation import resolve_bbox
+    assert resolve_bbox([np.int64(10), np.int64(10), np.int64(50), np.int64(50)],
+                        400, 300) == [10, 10, 50, 50]
+    assert resolve_bbox([np.float32(10.9), np.float32(10.0),
+                         np.float32(50.0), np.float32(50.0)], 400, 300) == [10, 10, 50, 50]
+
+
+def test_bool_bbox_values_are_rejected():
+    """bool is an int subclass; a coordinate of True is a bug, not a 1."""
+    from app.models.wbia_orientation import resolve_bbox, OrientationInferenceError
+    with pytest.raises(OrientationInferenceError, match="non-numeric"):
+        resolve_bbox([True, 0, 10, 10], 400, 300)
+
+
+@pytest.mark.parametrize("bbox", [
+    [10.7, 10.2, 50.9, 50.9],
+    [-0.9, -0.9, 500.5, 400.5],
+    [379.6, 10.1, 50.8, 50.2],
+])
+def test_fractional_bboxes_agree_with_actual_numpy_slice(bbox):
+    """Fractional w/h too — grounded against NumPy after the same int() rule."""
+    from app.models.wbia_orientation import resolve_bbox
+    img = np.zeros((300, 400, 3))
+    x, y, w, h = (int(v) for v in bbox)
+    actual = img[y:y + h, x:x + w]
+    eff = resolve_bbox(bbox, 400, 300)
+    assert (eff[2], eff[3]) == (actual.shape[1], actual.shape[0])
+
+
+def test_predict_batch_runs_three_forwards_for_the_whole_image_not_per_bbox():
+    """Batched: 3 TTA forwards TOTAL for N bboxes, not 3N."""
+    m = _model(hflip=True, vflip=True)
+    m.model.reset_mock()
+    m.predict_batch(RGB, [[10, 10, 100, 100], [50, 50, 60, 60], [0, 0, 400, 300]])
+    assert m.model.call_count == 3, "expected base+hflip+vflip on ONE stacked batch"
+
+
+def test_batched_rows_stay_aligned_with_their_bboxes():
+    """A misaligned row would attach one bbox's theta to another's crop."""
+    from app.models.wbia_orientation import WbiaOrientationModel, compute_theta
+    m = WbiaOrientationModel()
+    m.model_id, m.device, m.imsize = "t", "cpu", (224, 224)
+    m.hflip = m.vflip = False
+    rows = torch.tensor([[0.5, 0.5, 1.0, 0.5, 0.1],      # -> 90 deg
+                         [0.5, 0.5, 0.5, 0.0, 0.1],      # -> 0 deg
+                         [0.5, 0.5, 0.0, 0.5, 0.1]])     # -> 270 deg
+    logits = torch.log(rows.clamp(1e-9, 1 - 1e-9) / (1 - rows.clamp(1e-9, 1 - 1e-9)))
+    m.model = MagicMock(side_effect=lambda x, *a, **k: logits)
+    out = m.predict_batch(RGB, [[0, 0, 100, 100], [10, 10, 50, 50], [20, 20, 30, 30]])
+    for r, expected in zip(out, rows.tolist()):
+        assert r["theta"] == pytest.approx(compute_theta(expected), abs=1e-6)
+
+
+def test_empty_bbox_list_returns_empty_without_inference():
+    m = _model()
+    m.model.reset_mock()
+    assert m.predict_batch(RGB, []) == []
+    assert m.model.call_count == 0
+
+
+def test_preprocess_produces_the_reference_tensor_shape_and_dtype():
+    """Pins the preprocessing contract the mocked backbone cannot: 224x224,
+    float32 (the reference's .float() after skimage's float64), 3 channels."""
+    m = _model()
+    img = np.random.RandomState(2).rand(300, 400, 3)
+    x = m._preprocess(img, [10, 10, 100, 100])
+    assert x.shape == (1, 3, 224, 224)
+    assert x.dtype == torch.float32
+
+
+def test_preprocess_normalizes_with_imagenet_statistics():
+    """A constant image maps to (value-mean)/std per channel — catches a dropped
+    or altered Normalize."""
+    m = _model()
+    img = np.full((300, 400, 3), 0.485, dtype=np.float64)
+    x = m._preprocess(img, [0, 0, 400, 300])
+    assert x[0, 0].mean().item() == pytest.approx(0.0, abs=1e-4)
+
+
+def test_preprocess_degenerate_crop_uses_the_full_image():
+    """animal_wbia.py:25-28 — and the result must differ from a real crop."""
+    m = _model()
+    img = np.random.RandomState(3).rand(300, 400, 3)
+    full = m._preprocess(img, [0, 0, 400, 300])
+    degenerate = m._preprocess(img, [0, 0, 0, 0])       # empty -> full image
+    assert torch.allclose(full, degenerate)
+
+
 # ----------------------------------------------------------------- loading
 
 def test_registered_in_model_registry():
@@ -321,6 +448,12 @@ def test_load_requires_a_checkpoint():
     from app.models.wbia_orientation import WbiaOrientationModel
     with pytest.raises(ValueError, match="checkpoint_path is required"):
         WbiaOrientationModel().load(model_id="t")
+
+
+def test_sigmoid_of_inf_is_finite_so_only_nan_survives_the_head():
+    """Documents why the NaN tests use NaN: an inf logit saturates to 1.0."""
+    assert torch.sigmoid(torch.tensor([float("inf")])).item() == 1.0
+    assert math.isnan(torch.sigmoid(torch.tensor([float("nan")])).item())
 
 
 def test_load_uses_strict_state_dict():


### PR DESCRIPTION
Restores annotation rotation for whale sharks. Companion to #34 (which stops the *other* half of the same root cause).

## The regression

Sharkbook lost `theta` when it moved to the v2 ml-service. Measured on its production DB via `FEATURE."REVISION"` — `ANNOTATION."VERSION"` is useless for dating because `ml_service_idempotency.sql` mass-rewrites it:

| month | theta_zero | theta_real | **% zero** |
|---|---|---|---|
| 2025-02 → 2026-05 (16 months) | ~230 | ~9,200 | **~2–4%** |
| **2026-06** | 132 | 96 | **58%** |
| **2026-07** | **186** | **4** | **98%** |

**~315 whale shark annotations have `theta = 0` that should carry a real rotation.**

**Cause.** `/pipeline/` takes theta only from the detector, and `whaleshark_v0` is a **lightnet** model — `lightnet_model.py` has zero theta references, so `pipeline_router:198` defaults it to `0.0`. Under WBIA, theta came from `orientation.whaleshark.v3` via `wbia-plugin-orientation`. ml-service loaded that checkpoint under `densenet-orientation`, which misreads it as a 5-class classifier (#33) — producing fabricated viewpoint labels **and never producing theta at all**.

**This outranks #33.** A wrong viewpoint corrupts the candidate *filter*; a missing theta means the crop was never rotated, so **MiewID embedded a tilted animal**. The embedding is wrong at the source, and every match touching those annotations is degraded — including matches initiated from healthy ones. #33 is fixable by nulling a column. This needs embeddings re-extracted.

## What this adds

A `wbia-orientation` model type that runs those checkpoints **as the regressors they are** — 5 sigmoid outputs `[xc, yc, xt, yt, w]` in [0,1], from which theta is derived — and returns **theta, never a label**.

The reference is ported exactly: `imageio` decode · axis-aligned crop · degenerate-crop full-frame fallback · `skimage` bicubic+anti-alias at 224 · ToTensor + ImageNet Normalize · float32 cast · sigmoid head · hflip/vflip TTA with per-axis un-flip and 3-way mean · `arctan2(yt-yc, xt-xc) + 90°` on **normalized** coords.

**Wildbook needs no Java change.** `MlServiceProcessor` already reads each result's theta (`:366` → `:368` → `:475 featureParams(bbox, theta, viewpoint)`) and never reassigns it, so correct rotation flows through and persists.

## Fidelity is the whole point

This port's failure mode is being **silently wrong by an angle** — indistinguishable from correct output downstream, exactly like #33's labels, which went unnoticed for two months. So it is not argued, it is measured.

**The gate** (`scripts/preflight/`) executes the **pinned reference and the port live on the same bytes** and compares them to each other. No frozen expected values — those would pin one implementation's output and rot on any bump. The manifest carries *inputs and identity* (fixture byte hashes, exact bboxes, checkpoint SHA-256s, reference commit, per-stratum minimums).

```
port vs reference (whaleshark_v3, production pins):
    worst circular theta error : 7.726e-07 rad   (gate: <= 1e-5)
    worst coord elementwise err: 1.192e-07        (gate: <= 1e-6)
```

**timm vs the reference `cls_hrnet`** — "strict load succeeds" was rejected as evidence, since it proves key/shape compatibility, not identical forward computation. Measured instead: **3 checkpoints × 6 inputs, worst 5.960e-08** = 1 ULP of float32. Equivalent; no vendoring.

It runs at **host preflight**, not CI: the checkpoints are hundreds of MB, and a *skipped* test is not a safeguard.

## Correctness properties

- **FAIL-CLOSED at request level.** If orientation fails for any bbox: `500`, no results, and neither classify nor extract runs for **any** bbox. Soft-failing would fall back to the detector's `0.0` and embed an unrotated crop — *the regression itself, reintroduced by its own fix*. A **predicted** `0.0` is valid; a **missing** one is never defaulted.
- **`effective_bbox` reaches all three consumers** — classify, extract, and the **emitted** result. The emitted one matters most: Wildbook persists the result's bbox next to theta, so leaving the detector's original would *store* a bbox naming one region beside a theta describing another. `detector_bbox` is retained for audit.
- **NumPy slicing does not clamp.** `x1=-20, w=500` on a 400px image crops the image's **far edge**; an overrun silently truncates. `resolve_bbox()` reproduces the reference's real slice via `slice(start,stop).indices(dim)`.
- **Integerization is `int()`, truncate-toward-zero**, matching `pipeline_router:218`. Load-bearing: `floor(-0.5) == -1` resolves from the far edge; `int(-0.5) == 0` does not.
- **Never emits `label`/`probability`/`class_id`** — nothing a viewpoint consumer could mistake for a classification.
- **Rejects a pre-rotated crop** — the reference consumes the axis-aligned bbox and derives theta itself.
- **`predict_batch`**: one **ordered** result per bbox or atomic failure; batched to 3 TTA forwards per image, not 3 per bbox.
- **`theta_source`** (`orientation` | `detector`) is emitted so a stored angle's provenance is auditable.

## Deliberate deviation

**RGB canonicalization** (grayscale replicated, RGBA alpha dropped). The reference *raises* on both — an exception is not a specification, and failing a detection because a frame is grayscale (routine for IR/night capture) is worse. `(H,W,3)` passes through untouched, so RGB fidelity is unaffected. Validated by converting fixtures to RGB externally and requiring the reference to agree.

## Review

Design reviewed to convergence over **six rounds**, then the implementation over **two more**. Findings that would otherwise have shipped: fail-closed (twice — the model, then the router); a "gate" with no threshold that compared against historical annotation state; grayscale/RGBA strata that would have diffed against a crash; NumPy far-edge slicing; the emitted bbox retaining the detector's; a build-breaking duplicate Pillow pin — which exposed that the gate had been run against a stack production doesn't install, so both gates were re-run on the real pins.

**193 tests pass** (61 unit + 22 router integration + existing).

## Deploying

Config only names the new type once this is merged; `main.py` eager-loads every entry, so **run the host preflight first** (`scripts/preflight/README.md`). Re-add the three checkpoints under new `-theta` ids, then set `orientation_model_id` on Sharkbook's `Rhincodon.typus`.

⚠️ Naming isolation is **not** startup isolation — an install that never references a model still loads it. This exact failure mode downed the shared service on 2026-07-16.

## Follow-ups

- **Backfill** the ~315: recompute theta and **update in place** — never re-detect, because `MlServiceProcessor.findExistingAnnotation` dedups on bbox **and theta**, so a corrected theta would create a duplicate rather than update. Then re-extract embeddings and bump `ANNOTATION."VERSION"`.
- Per-install model configuration, so startup risk is proportional to which install needs a model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
