### PR TITLE
fix: main does not build — pin scikit-image for the container's Python 3.10

### DIFF
--- a/docs/plans/2026-07-16-wbia-orientation-theta-design.md
+++ b/docs/plans/2026-07-16-wbia-orientation-theta-design.md
@@ -481,6 +481,38 @@ hand-computed theta (`[0.5,0.5,1.0,0.5,0.1]` → `arctan2(0,0.5)+90° = 90°`); 
 `label`/`probability` key ever emitted; rejected from the classify slot; NaN theta
 → fail-closed, not 0.0.
 
+## Precondition for any FUTURE amphibian-reptile migration
+
+`orientation-fire-salamander` was removed from the registry rather than ported,
+because **no install references it**: amphibian-reptile has no `_mlservice_conf`
+at all — it is still entirely on legacy WBIA, where its `_detect_conf` says
+
+```json
+"orienter_algo": "plugin:orientation",
+"orienter_model_tag": "salamander_fire_v2"
+```
+
+i.e. it uses WBIA's own orientation plugin, which reads those 5 outputs as
+coordinates and derives theta **correctly**. The ml-service entry had been
+eager-loaded on every startup since it was added, referenced by nobody, and would
+have emitted garbage viewpoints (#33) if anything had pointed at it.
+
+The irony is instructive: **the salamander install still has correct theta
+precisely because it never migrated.** Sharkbook migrated and lost it.
+
+**So when amphibian-reptile is upgraded to the v2 ml-service, it MUST get a
+`salamander_fire_v2-theta` entry (`wbia-orientation`,
+`/datasets/orientation.salamander_fire_adult.v2.pth`) and an
+`orientation_model_id` on `Salamandra.salamandra` / `Salamandra.infraimmaculata`.**
+Without it that install walks into exactly Sharkbook's regression: its detector
+(`salamander_fire_v2`) is **lightnet**, which never emits thetas, so theta would
+silently drop to 0 and MiewID would start embedding tilted salamanders.
+
+`Bombina.variegata` (yellow-bellied toad) has the same shape —
+`orienter_algo: plugin:orientation`, `orienter_model_tag: yellow_bellied_toad_v0`
+— and would need the same treatment, but that checkpoint is not in the registry at
+all today.
+
 ## Backfill pathway (separate PR)
 
 For the ~315 affected annotations, theta must be recomputed **and embeddings

--- a/docs/plans/2026-07-16-wbia-orientation-theta-design.md
+++ b/docs/plans/2026-07-16-wbia-orientation-theta-design.md
@@ -363,18 +363,43 @@ put — bumping it on a service shared by five installs is out of scope here —
 it is part of this contract, because imageio's decoding is not reproducible from
 the imageio pin alone.
 
+▲▲▲▲▲▲▲ **Corrected AGAIN — the deployment stack is not `requirements.txt` alone.**
+Revision 6 pinned `scikit-image==0.26.0` (from a dev machine's Python 3.12) and
+recorded `torch==2.10.0+cu128`. Both are wrong for the container, and the image
+build proved it:
+
+    ERROR: Ignored the following versions that require a different python version:
+           ... 0.26.0 Requires-Python >=3.11
+    ERROR: No matching distribution found for scikit-image==0.26.0
+
+`docker/dockerfile` is `FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04` → **Python
+3.10**, and it pins **`torch==2.1.2` / `torchvision==0.16.2`** itself — torch is
+absent from `requirements.txt` entirely. The real contract is
+**requirements.txt + dockerfile + the base image's Python**.
+
 ```
-scikit-image==0.26.0      # NEW: resize(order=3, anti_aliasing=True)
-imageio==2.37.3           # NEW: decode
+scikit-image==0.25.2      # NEW. 0.26+ requires Python >=3.11; the image is 3.10
+imageio==2.37.3           # NEW (py3.10-compatible)
 Pillow==10.1.0            # pre-existing; imageio's JPEG/PNG backend
 numpy==1.26.3             # pre-existing
-timm==1.0.19              # pre-existing; equivalence re-verified on THIS version
-torch==2.10.0+cu128
+timm==1.0.19              # pre-existing
+torch==2.1.2              # from docker/dockerfile, NOT requirements.txt
+torchvision==0.16.2       # from docker/dockerfile
+python 3.10               # from the base image
 ```
 
+▲▲▲▲▲▲▲ **The gate must run INSIDE THE BUILT IMAGE, not on the host's Python.**
+Every version of this design so far claimed the preflight validates the deployment
+stack while it was actually executed in a Python 3.12 venv with torch 2.10 — so it
+has never once run on the stack that ships. That is the same "measured the
+convenient artifact" error the rest of this document exists to correct, and no
+amount of review catches it: eight review rounds did not, and a seven-second
+`docker compose build` did. `scripts/preflight/README.md` specifies the container
+invocation.
+
 The gate, its input manifest, and the reference runner live in
-`scripts/preflight/` and are release-blocking on the host. Re-run on ANY bump to
-these lines.
+`scripts/preflight/` and are release-blocking. Re-run on ANY bump to the lines
+above — including the dockerfile's torch and the base image's Python.
 
 Both scikit-image and imageio are **new dependencies on a service shared by 5
 installs** — which is itself why the host preflight above is mandatory. Re-run the

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,11 @@ opencv-python==4.8.1.78
 # is already pinned above (Pillow==10.1.0) -- that pin is part of this contract.
 # Re-run the host preflight fidelity gate on ANY bump to scikit-image, imageio,
 # Pillow, or timm.
-scikit-image==0.26.0
+# NB pinned for the CONTAINER's Python 3.10 (nvidia/cuda:12.1.1-runtime-ubuntu22.04),
+# not a dev machine's newer Python: scikit-image 0.26+ requires >=3.11 and will not
+# resolve in the image. torch/torchvision are pinned in docker/dockerfile (2.1.2 /
+# 0.16.2) and are part of this fidelity contract too.
+scikit-image==0.25.2
 imageio==2.37.3
 aiofiles==23.2.1
 python-jose==3.3.0

--- a/scripts/preflight/README.md
+++ b/scripts/preflight/README.md
@@ -37,7 +37,10 @@ build` caught it (`scikit-image==0.26.0` requires Python >=3.11 and cannot insta
 in the image at all).
 
 ```bash
-docker compose -f docker/docker-compose.prod.yml build
+# Tag the image explicitly.  Compose otherwise chooses a project-derived tag
+# (for example `docker-ml-service`), while the run command below uses
+# `ml-service`.
+docker build -t ml-service -f docker/dockerfile .
 
 docker run --rm --gpus all \
   -v "$MODELS_DIR:/datasets:ro" \

--- a/scripts/preflight/README.md
+++ b/scripts/preflight/README.md
@@ -27,12 +27,33 @@ Compared per sample: circular theta error, elementwise `coords_normalized`,
 `effective_bbox` exact equality, and `predict_batch` count/order. Theta alone can
 pass while coordinates are wrong.
 
-## Running it
+## Running it — INSIDE THE BUILT IMAGE
+
+Run it in the container, **not** on the host's Python. The image is the stack that
+ships; a host venv is not. Earlier revisions of this gate ran on Python 3.12 with
+torch 2.10 while the image is **Python 3.10 with torch 2.1.2** — so the gate
+"passed" for a stack that does not exist in production, and only `docker compose
+build` caught it (`scikit-image==0.26.0` requires Python >=3.11 and cannot install
+in the image at all).
 
 ```bash
-python scripts/preflight/run_gate.py --manifest scripts/preflight/manifest.json \
-                                     --fixtures /path/to/fixtures
+docker compose -f docker/docker-compose.prod.yml build
+
+docker run --rm --gpus all \
+  -v "$MODELS_DIR:/datasets:ro" \
+  -v "$PWD/scripts/preflight:/app/scripts/preflight:ro" \
+  -v "$PWD/fixtures:/fixtures:ro" \
+  -v /path/to/wbia-plugin-orientation:/reference:ro \
+  ml-service \
+  python3 scripts/preflight/run_gate.py \
+      --manifest scripts/preflight/manifest.json \
+      --fixtures /fixtures
 ```
+
+`reference_runner.py` needs the `wbia-plugin-orientation` checkout mounted (it
+loads the plugin's config and `cls_hrnet` via importlib) plus `yacs`. Neither is a
+runtime dependency of ml-service, which is another reason this is a preflight and
+not CI.
 
 Emits an artifact recording reference outputs, port outputs, and the full
 environment. **Re-run on any bump to `scikit-image`, `imageio`, `Pillow`, `timm`,
@@ -50,7 +71,16 @@ Matches `requirements.txt`, not a convenience venv — an earlier run validated
 `10.1.0 / 1.26.3 / 1.0.19`, i.e. it proved fidelity for a stack production does
 not install.
 
+The stack that actually ships is **requirements.txt + dockerfile + the base
+image's Python** — not requirements.txt alone:
+
 ```
-Pillow==10.1.0     scikit-image==0.26.0    torch==2.10.0+cu128
-numpy==1.26.3      imageio==2.37.3         timm==1.0.19
+python 3.10              # base image: nvidia/cuda:12.1.1-runtime-ubuntu22.04
+torch==2.1.2             # docker/dockerfile (NOT in requirements.txt)
+torchvision==0.16.2      # docker/dockerfile
+Pillow==10.1.0           numpy==1.26.3        timm==1.0.19
+scikit-image==0.25.2     imageio==2.37.3
 ```
+
+`scikit-image` is capped at 0.25.2 because 0.26+ requires Python >=3.11. Pinning a
+newer version from a dev machine's Python breaks the image build outright.


### PR DESCRIPTION
**Main does not build.** #35 merged with a `scikit-image` pin that cannot install in the container.

```
ERROR: Ignored the following versions that require a different python version:
       ... 0.26.0 Requires-Python >=3.11
ERROR: No matching distribution found for scikit-image==0.26.0
failed to solve: process "/bin/sh -c pip3 install --no-cache-dir -r requirements.txt"
                 did not complete successfully: exit code: 1
```

`docker/dockerfile` is `FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04` → **Python 3.10**. Confirmed against PyPI:

| version | `requires_python` | cp310 wheel |
|---|---|---|
| **0.25.2** | `>=3.10` | ✅ |
| 0.26.0 | `>=3.11` | ❌ |

I pinned 0.26.0 because that is what resolved in a dev venv on Python 3.12.

## Fix

`scikit-image==0.25.2` — newest release supporting Python 3.10. **Gate re-run against it: theta `7.726e-07`, coords `1.192e-07`** — unchanged, so the skimage version doesn't move the result. 221 tests pass.

## The actual lesson, recorded in the design + preflight README

**The deployment stack is not `requirements.txt` alone.** It is `requirements.txt` **+ `docker/dockerfile` + the base image's Python**. `torch` isn't in requirements at all — the dockerfile pins `torch==2.1.2 / torchvision==0.16.2`, while the gate had been running against **torch 2.10 on Python 3.12**.

So the fidelity gate has **never run on the stack that ships**, across every revision, while claiming to. The preflight README now specifies running it **inside the built image**, which is the only place that stack exists:

```bash
docker run --rm --gpus all -v "$MODELS_DIR:/datasets:ro" ... ml-service \
  python3 scripts/preflight/run_gate.py --manifest ... --fixtures /fixtures
```

Worth naming plainly: **eight review rounds missed this; `docker compose build` caught it in seven seconds.** Reviews reason about code — this was a fact about a package index and a base image. A review only sees what it's pointed at, and `docker/dockerfile` was never in any review prompt. (The earlier review did flag *"and no Torch version"*, which was exactly the thread to pull, and I didn't.)

This is the same error the whole theta change exists to correct: measuring the convenient artifact instead of the real one.

## Urgency

Main is unbuildable until this lands. It's a one-line pin change plus documentation; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
