### PR TITLE
Image-fetch resilience: survive slow Wildbooks without starving inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+- Image-fetch resilience (design: docs/plans/2026-08-14-image-fetch-resilience-design.md):
+  image downloads now use a shared client with explicit timeouts and a 60s total
+  deadline, run outside the inference semaphores behind a bounded admission gate,
+  stream with a 50 MB cap and 150 MP header check, and map failures to
+  retry-ladder-correct statuses (504/502 retryable, 400 permanent, 503 saturated,
+  413 oversized body). Fixes the GiraffeSpotter timeout→500 retry storm
+  (2026-08-14) and removes slow-Wildbook head-of-line blocking.
+
 ## v1.0.0 — Wildbook ML Service GA
 
 First stable release of the Wildbook ML Service, a FastAPI replacement for the

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 # Create FastAPI app
 app = FastAPI()
 
+from app.middleware import BodyLimitMiddleware
+from app.utils import image_uri
+
+MAX_REQUEST_BODY_BYTES = int(os.getenv("MAX_REQUEST_BODY_BYTES", "4194304"))
+app.add_middleware(BodyLimitMiddleware, max_bytes=MAX_REQUEST_BODY_BYTES)
+
 # Parse command line arguments
 parser = argparse.ArgumentParser(description='FastAPI Model Serving Application')
 parser.add_argument('--device', type=str, default='cuda', 
@@ -35,26 +41,31 @@ parser.add_argument('--port', type=int, default=8888,
                    help='Port to run the server on')
 parser.add_argument('--reload', action='store_true', 
                    help='Enable auto-reload')
-parser.add_argument('--workers', type=int, default=1, 
+parser.add_argument('--workers', type=int, default=1,
                    help='Number of worker processes')
+parser.add_argument('--limit-concurrency', type=int, default=32,
+                   help='Max concurrent connections per worker; excess get 503 '
+                        'before their bodies are read (bounds parse-time memory)')
 args = parser.parse_args()
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("app.main:app", host=args.host, port=args.port, 
-               reload=args.reload, workers=args.workers)
+    uvicorn.run("app.main:app", host=args.host, port=args.port,
+               reload=args.reload, workers=args.workers,
+               limit_concurrency=args.limit_concurrency)
 
 @app.on_event("startup")
 async def startup_event():
     """Initialize the application on startup.
-    
+
     This function is called when the FastAPI application starts up. It performs the following actions:
     1. Creates a ModelHandler instance
     2. Loads the model configuration from model_config.json
     3. Initializes and loads all configured models with the specified device
-    
+
     The models are stored in the application state and can be accessed via request.app.state.model_handler.
     """
+    image_uri.init_image_fetch()
     # Initialize model handler
     model_handler = ModelHandler()
     app.state.device = args.device
@@ -104,6 +115,7 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     """Clean up models and free GPU memory on shutdown."""
+    await image_uri.shutdown_image_fetch()
     import torch
     if hasattr(app.state, 'model_handler'):
         for model_id, info in app.state.model_handler.models.items():

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -4,6 +4,10 @@ Bounds per-request parse-time memory: FastAPI/Pydantic materializes the
 whole body before route handlers run, so the cap must sit below them.
 Aggregate concurrency is bounded separately by uvicorn --limit-concurrency."""
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class BodyLimitMiddleware:
     def __init__(self, app, max_bytes: int):
@@ -48,12 +52,14 @@ class BodyLimitMiddleware:
 
         try:
             await self.app(scope, counting_receive, guarded_send)
-        except Exception:
+        except Exception as exc:
             # the disconnect we injected may surface as ClientDisconnect (or
             # similar) from the app; if we already answered 413 that is
             # expected — anything else is a real error
             if not rejected:
                 raise
+            logger.warning(
+                "Suppressed exception after body-cap 413 was delivered: %r", exc)
 
     @staticmethod
     async def _reject(send):

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,64 @@
+"""Pure-ASGI request-body cap.
+
+Bounds per-request parse-time memory: FastAPI/Pydantic materializes the
+whole body before route handlers run, so the cap must sit below them.
+Aggregate concurrency is bounded separately by uvicorn --limit-concurrency."""
+
+
+class BodyLimitMiddleware:
+    def __init__(self, app, max_bytes: int):
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        declared = headers.get(b"content-length")
+        if declared is not None and declared.isdigit() and int(declared) > self.max_bytes:
+            await self._reject(send)
+            return
+
+        received = 0
+        response_started = False
+
+        async def counting_receive():
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    raise _BodyTooLarge()
+            return message
+
+        async def tracking_send(message):
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, counting_receive, tracking_send)
+        except _BodyTooLarge:
+            if not response_started:
+                await self._reject(send)
+            # else: response already in flight; connection ends here
+
+    @staticmethod
+    async def _reject(send):
+        body = b'{"detail":"Request body too large"}'
+        await send({
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})
+
+
+class _BodyTooLarge(Exception):
+    pass

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -22,29 +22,38 @@ class BodyLimitMiddleware:
             return
 
         received = 0
-        response_started = False
+        rejected = False          # we sent the 413; swallow the app's output
+        response_started = False  # app began responding; too late to reject
 
         async def counting_receive():
-            nonlocal received
+            nonlocal received, rejected
             message = await receive()
             if message["type"] == "http.request":
                 received += len(message.get("body", b""))
                 if received > self.max_bytes:
-                    raise _BodyTooLarge()
+                    if not response_started and not rejected:
+                        rejected = True
+                        await self._reject(send)
+                    # abort the app's body read; connection is done
+                    return {"type": "http.disconnect"}
             return message
 
-        async def tracking_send(message):
+        async def guarded_send(message):
             nonlocal response_started
+            if rejected:
+                return  # 413 already sent; drop the app's response
             if message["type"] == "http.response.start":
                 response_started = True
             await send(message)
 
         try:
-            await self.app(scope, counting_receive, tracking_send)
-        except _BodyTooLarge:
-            if not response_started:
-                await self._reject(send)
-            # else: response already in flight; connection ends here
+            await self.app(scope, counting_receive, guarded_send)
+        except Exception:
+            # the disconnect we injected may surface as ClientDisconnect (or
+            # similar) from the app; if we already answered 413 that is
+            # expected — anything else is a real error
+            if not rejected:
+                raise
 
     @staticmethod
     async def _reject(send):
@@ -58,7 +67,3 @@ class BodyLimitMiddleware:
             ],
         })
         await send({"type": "http.response.body", "body": body})
-
-
-class _BodyTooLarge(Exception):
-    pass

--- a/app/routers/classify_router.py
+++ b/app/routers/classify_router.py
@@ -1,11 +1,10 @@
 import logging
 from fastapi import APIRouter, HTTPException, Request, status, Depends
 from typing import Dict, Any, List, Optional
-import httpx
 import asyncio
 from pydantic import BaseModel, Field
 from app.models.model_handler import ModelHandler
-from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_response
+from app.utils.image_uri import fetch_image_for_request, admission_slot, sanitize_uri_for_response
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
@@ -44,7 +43,7 @@ async def classify_image(
     Raises:
         HTTPException: If there's an error processing the request
     """
-    async with classify_semaphore:
+    async with admission_slot():
         try:
             # Validate bbox format if provided
             if classify_request.bbox is not None and len(classify_request.bbox) != 4:
@@ -52,7 +51,7 @@ async def classify_image(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Bounding box must contain exactly 4 values: [x, y, width, height]"
                 )
-            
+
             # Get the model instance
             model = handler.get_model(classify_request.model_id)
             if not model:
@@ -64,7 +63,7 @@ async def classify_image(
                         "available_models": available_models
                     }
                 )
-            
+
             # Check if the model supports classification (has predict method)
             if not hasattr(model, 'predict'):
                 raise HTTPException(
@@ -73,35 +72,22 @@ async def classify_image(
                 )
 
             # Resolve image bytes from URI (URL, data URI, or local path)
-            try:
-                image_bytes = await resolve_image_uri(classify_request.image_uri)
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=str(e)
+            image_bytes = await fetch_image_for_request(classify_request.image_uri)
+
+            async with classify_semaphore:
+                # Run classification in a thread pool
+                result = await run_in_threadpool(
+                    model.predict,
+                    image_bytes=image_bytes,
+                    bbox=classify_request.bbox,
+                    theta=classify_request.theta
                 )
-                with open(file_path, "rb") as f:
-                    image_bytes = f.read()
-            
-            # Run classification in a thread pool
-            result = await run_in_threadpool(
-                model.predict,
-                image_bytes=image_bytes,
-                bbox=classify_request.bbox,
-                theta=classify_request.theta
-            )
-            
-            # Add request metadata to result
-            result['image_uri'] = sanitize_uri_for_response(classify_request.image_uri)
-            
-            return result
-            
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Error downloading image: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Error downloading image: {str(e)}"
-            )
+
+                # Add request metadata to result
+                result['image_uri'] = sanitize_uri_for_response(classify_request.image_uri)
+
+                return result
+
         except HTTPException:
             raise
         except Exception as e:

--- a/app/routers/extract_router.py
+++ b/app/routers/extract_router.py
@@ -1,12 +1,11 @@
 import logging
 from fastapi import APIRouter, HTTPException, Request, status, Depends
 from typing import Dict, Any, List, Optional, Union
-import httpx
 import asyncio
 from pydantic import BaseModel, Field, model_validator
 from app.models.model_handler import ModelHandler
 from app.models.miewid import MiewidModel
-from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_response
+from app.utils.image_uri import fetch_image_for_request, admission_slot, sanitize_uri_for_response
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
@@ -64,7 +63,7 @@ async def extract_embeddings(
     Raises:
         HTTPException: If there's an error processing the request
     """
-    async with extract_semaphore:
+    async with admission_slot():
         try:
             # Validate bbox format if provided
             if extract_request.bbox is not None and len(extract_request.bbox) != 4:
@@ -72,7 +71,7 @@ async def extract_embeddings(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Bounding box must contain exactly 4 values: [x, y, width, height]"
                 )
-            
+
             # Get the model instance
             model = handler.get_model(extract_request.model_id)
             if not model:
@@ -84,94 +83,81 @@ async def extract_embeddings(
                         "available_models": available_models
                     }
                 )
-            
+
             # Check if the model is a MiewID model
             if not isinstance(model, MiewidModel):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Model '{extract_request.model_id}' is not a MiewID model. Only MiewID models support embeddings extraction."
                 )
-            
+
             # Resolve image bytes from URI (URL, data URI, or local path)
-            try:
-                image_bytes = await resolve_image_uri(extract_request.image_uri)
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=str(e)
+            image_bytes = await fetch_image_for_request(extract_request.image_uri)
+
+            async with extract_semaphore:
+                # Convert bbox to tuple of ints if provided. The underlying
+                # extract_embeddings expects integer pixel coordinates; v2
+                # senders may pass doubles (e.g. 12.0), so round down.
+                bbox_tuple = (
+                    tuple(int(v) for v in extract_request.bbox)
+                    if extract_request.bbox is not None else None
                 )
-                with open(file_path, "rb") as f:
-                    image_bytes = f.read()
-            
-            # Convert bbox to tuple of ints if provided. The underlying
-            # extract_embeddings expects integer pixel coordinates; v2
-            # senders may pass doubles (e.g. 12.0), so round down.
-            bbox_tuple = (
-                tuple(int(v) for v in extract_request.bbox)
-                if extract_request.bbox is not None else None
-            )
 
-            # Extract embeddings in a thread pool
-            embeddings = await run_in_threadpool(
-                model.extract_embeddings,
-                image_bytes=image_bytes,
-                bbox=bbox_tuple,
-                theta=extract_request.theta
-            )
+                # Extract embeddings in a thread pool
+                embeddings = await run_in_threadpool(
+                    model.extract_embeddings,
+                    image_bytes=image_bytes,
+                    bbox=bbox_tuple,
+                    theta=extract_request.theta
+                )
 
-            # MiewID returns shape [1, D]; flatten to a 1D list for the
-            # response so Wildbook v2 sees `embedding: [...]` rather than
-            # `embedding: [[...]]`.
-            embeddings_list = embeddings.tolist()
-            if embeddings_list and isinstance(embeddings_list[0], list):
-                flat_embedding = embeddings_list[0]
-            else:
-                flat_embedding = embeddings_list
+                # MiewID returns shape [1, D]; flatten to a 1D list for the
+                # response so Wildbook v2 sees `embedding: [...]` rather than
+                # `embedding: [[...]]`.
+                embeddings_list = embeddings.tolist()
+                if embeddings_list and isinstance(embeddings_list[0], list):
+                    flat_embedding = embeddings_list[0]
+                else:
+                    flat_embedding = embeddings_list
 
-            # Resolve extract-model version for the response so consumers
-            # can match against persisted embeddings by (method, version).
-            # Empty / None / "None" version values are treated as missing
-            # and fall back to "1" so the response never carries a
-            # literally-broken version string.
-            extract_model_info = handler.get_model_info(extract_request.model_id)
-            extract_model_version = "1"
-            if extract_model_info and isinstance(extract_model_info, dict):
-                extract_cfg = extract_model_info.get('config') or {}
-                raw_version = extract_cfg.get('version')
-                if raw_version is not None:
-                    version_str = str(raw_version).strip()
-                    if version_str and version_str.lower() != 'none':
-                        extract_model_version = version_str
+                # Resolve extract-model version for the response so consumers
+                # can match against persisted embeddings by (method, version).
+                # Empty / None / "None" version values are treated as missing
+                # and fall back to "1" so the response never carries a
+                # literally-broken version string.
+                extract_model_info = handler.get_model_info(extract_request.model_id)
+                extract_model_version = "1"
+                if extract_model_info and isinstance(extract_model_info, dict):
+                    extract_cfg = extract_model_info.get('config') or {}
+                    raw_version = extract_cfg.get('version')
+                    if raw_version is not None:
+                        version_str = str(raw_version).strip()
+                        if version_str and version_str.lower() != 'none':
+                            extract_model_version = version_str
 
-            # Prepare response.
-            #
-            # Wildbook v2 contract:
-            #   - top-level `success: True`
-            #   - top-level `embedding` (singular, flat array of doubles)
-            #   - `embedding_model_id` + `embedding_model_version`
-            # Legacy keys (`embeddings`, `embeddings_shape`, `model_id`)
-            # are kept so existing test scripts continue working.
-            result = {
-                'success': True,
-                'model_id': extract_request.model_id,
-                'embedding': flat_embedding,
-                'embedding_model_id': extract_request.model_id,
-                'embedding_model_version': extract_model_version,
-                'embeddings': embeddings_list,
-                'embeddings_shape': list(embeddings.shape),
-                'bbox': extract_request.bbox,
-                'theta': extract_request.theta,
-                'image_uri': sanitize_uri_for_response(extract_request.image_uri)
-            }
+                # Prepare response.
+                #
+                # Wildbook v2 contract:
+                #   - top-level `success: True`
+                #   - top-level `embedding` (singular, flat array of doubles)
+                #   - `embedding_model_id` + `embedding_model_version`
+                # Legacy keys (`embeddings`, `embeddings_shape`, `model_id`)
+                # are kept so existing test scripts continue working.
+                result = {
+                    'success': True,
+                    'model_id': extract_request.model_id,
+                    'embedding': flat_embedding,
+                    'embedding_model_id': extract_request.model_id,
+                    'embedding_model_version': extract_model_version,
+                    'embeddings': embeddings_list,
+                    'embeddings_shape': list(embeddings.shape),
+                    'bbox': extract_request.bbox,
+                    'theta': extract_request.theta,
+                    'image_uri': sanitize_uri_for_response(extract_request.image_uri)
+                }
 
-            return result
-            
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Error downloading image: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Error downloading image: {str(e)}"
-            )
+                return result
+
         except HTTPException:
             raise
         except Exception as e:

--- a/app/routers/pipeline_router.py
+++ b/app/routers/pipeline_router.py
@@ -2,7 +2,6 @@ import logging
 import math
 from fastapi import APIRouter, HTTPException, Request, status, Depends
 from typing import Dict, Any, List, Optional
-import httpx
 import asyncio
 from pydantic import BaseModel, Field
 from app.models.model_handler import ModelHandler
@@ -12,7 +11,7 @@ from app.models.densenet_wilddog_cascade import DenseNetWildDogCascadeModel
 from app.models.miewid import MiewidModel
 from app.models.densenet_orientation import DenseNetOrientationModel
 from app.models.wbia_orientation import WbiaOrientationModel, OrientationInferenceError
-from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_response, sanitize_uri_for_logging
+from app.utils.image_uri import fetch_image_for_request, admission_slot, sanitize_uri_for_response, sanitize_uri_for_logging
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
@@ -57,7 +56,7 @@ async def run_pipeline(
     Raises:
         HTTPException: If there's an error processing the request
     """
-    async with pipeline_semaphore:
+    async with admission_slot():
         try:
             # Validate all models exist and are of correct types
             predict_model = handler.get_model(pipeline_request.predict_model_id)
@@ -133,363 +132,352 @@ async def run_pipeline(
                     )
             
             # Resolve image bytes from URI (URL, data URI, or local path)
-            try:
-                image_bytes = await resolve_image_uri(pipeline_request.image_uri)
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=str(e)
-                )
-            
-            # Step 1: Run prediction to get bboxes
-            logger.info(f"Running prediction with model {pipeline_request.predict_model_id}")
+            image_bytes = await fetch_image_for_request(pipeline_request.image_uri)
 
-            # Resolve extract-model version once for the response. The
-            # Wildbook v2 contract requires embedding_model_id +
-            # embedding_model_version on every result so consumers can
-            # match against persisted embeddings without consulting a
-            # second config source. Empty / None / "None" version values
-            # are treated as missing and fall back to "1" so the response
-            # never carries a literally-broken version string.
-            extract_model_info = handler.get_model_info(pipeline_request.extract_model_id)
-            extract_model_version = "1"
-            if extract_model_info and isinstance(extract_model_info, dict):
-                extract_cfg = extract_model_info.get('config') or {}
-                raw_version = extract_cfg.get('version')
-                if raw_version is not None:
-                    version_str = str(raw_version).strip()
-                    if version_str and version_str.lower() != 'none':
-                        extract_model_version = version_str
+            async with pipeline_semaphore:
+                # Step 1: Run prediction to get bboxes
+                logger.info(f"Running prediction with model {pipeline_request.predict_model_id}")
 
-            # Get model info for default parameters
-            model_info = handler.get_model_info(pipeline_request.predict_model_id)
-            
-            # Prepare prediction parameters, overriding defaults with any provided parameters
-            predict_params = model_info['config'].copy()
-            if pipeline_request.predict_model_params:
-                predict_params.update(pipeline_request.predict_model_params)
-            
-            # Remove any parameters that shouldn't be passed to predict
-            predict_params.pop('model_path', None)
-            predict_params.pop('device', None)
-            
-            # Run prediction in a thread pool
-            predict_result = await run_in_threadpool(
-                predict_model.predict,
-                image_bytes=image_bytes,
-                **predict_params
-            )
-            
-            # Step 2: Filter bboxes by score threshold
-            filtered_bboxes = []
-            
-            # Handle different prediction result formats
-            if 'bboxes' in predict_result and 'scores' in predict_result:
-                # YOLO format: separate arrays for bboxes, scores, class_ids, etc.
-                bboxes = predict_result.get('bboxes', [])
-                scores = predict_result.get('scores', [])
-                class_ids = predict_result.get('class_ids', [])
-                class_names = predict_result.get('class_names', [])
-                thetas = predict_result.get('thetas', [])
+                # Resolve extract-model version once for the response. The
+                # Wildbook v2 contract requires embedding_model_id +
+                # embedding_model_version on every result so consumers can
+                # match against persisted embeddings without consulting a
+                # second config source. Empty / None / "None" version values
+                # are treated as missing and fall back to "1" so the response
+                # never carries a literally-broken version string.
+                extract_model_info = handler.get_model_info(pipeline_request.extract_model_id)
+                extract_model_version = "1"
+                if extract_model_info and isinstance(extract_model_info, dict):
+                    extract_cfg = extract_model_info.get('config') or {}
+                    raw_version = extract_cfg.get('version')
+                    if raw_version is not None:
+                        version_str = str(raw_version).strip()
+                        if version_str and version_str.lower() != 'none':
+                            extract_model_version = version_str
+
+                # Get model info for default parameters
+                model_info = handler.get_model_info(pipeline_request.predict_model_id)
                 
-                for i, (bbox, score) in enumerate(zip(bboxes, scores)):
-                    if score >= pipeline_request.bbox_score_threshold:
-                        filtered_bboxes.append({
-                            'bbox': bbox,
-                            'score': score,
-                            'class_id': class_ids[i] if i < len(class_ids) else None,
-                            'class': class_names[i] if i < len(class_names) else None,
-                            'theta': thetas[i] if i < len(thetas) else 0.0
-                        })
-            elif 'predictions' in predict_result:
-                # Standard format: list of prediction objects
-                for prediction in predict_result['predictions']:
-                    if prediction.get('score', 0) >= pipeline_request.bbox_score_threshold:
-                        filtered_bboxes.append(prediction)
-            
-            logger.info(f"Found {len(filtered_bboxes)} bboxes above threshold {pipeline_request.bbox_score_threshold}")
-            
-            # Step 2b: orientation FIRST, batched, when a theta regressor is
-            # configured. theta must be known before the crop is embedded, so this
-            # cannot run alongside classify/extract in the gather below. One
-            # predict_batch per image = 3 TTA forwards total, not 3 per bbox.
-            #
-            # FAIL-CLOSED, at REQUEST level: if orientation fails for ANY bbox we
-            # return 500 and emit nothing. Falling back to the detector's theta
-            # (lightnet always gives 0.0) would embed an unrotated crop -- exactly
-            # the regression this model type exists to repair. A *predicted* 0.0 is
-            # valid; a *missing* one is not, so it must not be defaulted. Partial
-            # success is also rejected: silently dropping a detection is how
-            # annotations go missing.
-            theta_regressor = isinstance(orientation_model, WbiaOrientationModel)
-            wbia_orientation_results = None
-            if theta_regressor and filtered_bboxes:
-                ori_bboxes = [bp.get('bbox', []) for bp in filtered_bboxes]
-                try:
-                    wbia_orientation_results = await run_in_threadpool(
-                        orientation_model.predict_batch,
-                        image_bytes=image_bytes,
-                        bboxes=ori_bboxes,
-                    )
-                except OrientationInferenceError as e:
-                    logger.error(f"Orientation failed; failing the request: {e}")
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail=f"Orientation model "
-                               f"'{pipeline_request.orientation_model_id}' could not "
-                               f"produce a trustworthy theta: {e}"
-                    )
-                # Ordered 1:1 is load-bearing -- a misaligned row would attach one
-                # bbox's theta to another's crop.
-                if len(wbia_orientation_results) != len(filtered_bboxes):
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail=f"Orientation returned "
-                               f"{len(wbia_orientation_results)} result(s) for "
-                               f"{len(filtered_bboxes)} bbox(es)."
-                    )
-                # Validate EVERY row here, not lazily inside the consumer loop.
-                # Checking only the count and then dereferencing per-bbox would let
-                # a malformed row N run classify/extract for rows 0..N-1 before the
-                # request failed -- request-level fail-closed must mean no consumer
-                # runs at all.
-                for idx, ori in enumerate(wbia_orientation_results):
-                    if not isinstance(ori, dict):
-                        raise HTTPException(
-                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=f"Orientation result {idx} is not an object.")
-                    th_val = ori.get('theta')
-                    if not isinstance(th_val, (int, float)) or isinstance(th_val, bool) \
-                            or not math.isfinite(float(th_val)):
-                        raise HTTPException(
-                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=f"Orientation result {idx} has a non-finite or "
-                                   f"missing theta: {th_val!r}")
-                    eb = ori.get('effective_bbox')
-                    if (not isinstance(eb, (list, tuple)) or len(eb) != 4
-                            or not all(isinstance(v, int) and not isinstance(v, bool)
-                                       for v in eb)):
-                        raise HTTPException(
-                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=f"Orientation result {idx} has a malformed "
-                                   f"effective_bbox: {eb!r}")
-
-            # Step 3: Run classification and extraction for each filtered bbox
-            pipeline_results = []
-            original_classify_results = []
-            original_extract_results = []
-            
-            for i, bbox_prediction in enumerate(filtered_bboxes):
-                bbox_coords = bbox_prediction.get('bbox', [])
-                if len(bbox_coords) != 4:
-                    logger.warning(f"Skipping bbox {i}: invalid coordinates {bbox_coords}")
-                    continue
+                # Prepare prediction parameters, overriding defaults with any provided parameters
+                predict_params = model_info['config'].copy()
+                if pipeline_request.predict_model_params:
+                    predict_params.update(pipeline_request.predict_model_params)
                 
-                # YOLO already returns bbox in [x, y, width, height] format, no conversion needed
-                x, y, width, height = bbox_coords
-                bbox_list = [int(x), int(y), int(width), int(height)]
-                theta = float(bbox_prediction.get('theta', 0.0))
-                theta_source = 'detector'
-                detector_bbox = list(bbox_coords)   # audit: what the detector said
-
-                if wbia_orientation_results is not None:
-                    ori = wbia_orientation_results[i]
-                    theta = float(ori['theta'])
-                    theta_source = 'orientation'
-                    # effective_bbox is the slice orientation ACTUALLY used (NumPy
-                    # slicing does not clamp, and a degenerate crop falls back to
-                    # the full frame). classify, extract and the emitted result
-                    # must all use it, or theta describes a region other than the
-                    # crop it rotates.
-                    bbox_list = list(ori['effective_bbox'])
-                    bbox_coords = bbox_list
-                elif bbox_list[2] <= 0 or bbox_list[3] <= 0:
-                    # Guard AFTER integerization: a raw width of 0.5 passes
-                    # `width <= 0` but int(0.5) == 0, so consumers would receive a
-                    # degenerate box. Only skip when orientation is NOT resolving
-                    # bboxes for us -- its degenerate-crop fallback needs to see these.
-                    logger.warning(f"Skipping bbox {i}: invalid dimensions "
-                                   f"width={width}, height={height} "
-                                   f"(integerized to {bbox_list[2]}x{bbox_list[3]})")
-                    continue
-
-                # Run orientation, classification, and extraction in parallel
-                tasks = []
-                task_names = []
-
-                classify_task = run_in_threadpool(
-                    classify_model.predict,
+                # Remove any parameters that shouldn't be passed to predict
+                predict_params.pop('model_path', None)
+                predict_params.pop('device', None)
+                
+                # Run prediction in a thread pool
+                predict_result = await run_in_threadpool(
+                    predict_model.predict,
                     image_bytes=image_bytes,
-                    bbox=bbox_list,
-                    theta=theta
+                    **predict_params
                 )
-                tasks.append(classify_task)
-                task_names.append('classify')
+                
+                # Step 2: Filter bboxes by score threshold
+                filtered_bboxes = []
+                
+                # Handle different prediction result formats
+                if 'bboxes' in predict_result and 'scores' in predict_result:
+                    # YOLO format: separate arrays for bboxes, scores, class_ids, etc.
+                    bboxes = predict_result.get('bboxes', [])
+                    scores = predict_result.get('scores', [])
+                    class_ids = predict_result.get('class_ids', [])
+                    class_names = predict_result.get('class_names', [])
+                    thetas = predict_result.get('thetas', [])
+                    
+                    for i, (bbox, score) in enumerate(zip(bboxes, scores)):
+                        if score >= pipeline_request.bbox_score_threshold:
+                            filtered_bboxes.append({
+                                'bbox': bbox,
+                                'score': score,
+                                'class_id': class_ids[i] if i < len(class_ids) else None,
+                                'class': class_names[i] if i < len(class_names) else None,
+                                'theta': thetas[i] if i < len(thetas) else 0.0
+                            })
+                elif 'predictions' in predict_result:
+                    # Standard format: list of prediction objects
+                    for prediction in predict_result['predictions']:
+                        if prediction.get('score', 0) >= pipeline_request.bbox_score_threshold:
+                            filtered_bboxes.append(prediction)
+                
+                logger.info(f"Found {len(filtered_bboxes)} bboxes above threshold {pipeline_request.bbox_score_threshold}")
+                
+                # Step 2b: orientation FIRST, batched, when a theta regressor is
+                # configured. theta must be known before the crop is embedded, so this
+                # cannot run alongside classify/extract in the gather below. One
+                # predict_batch per image = 3 TTA forwards total, not 3 per bbox.
+                #
+                # FAIL-CLOSED, at REQUEST level: if orientation fails for ANY bbox we
+                # return 500 and emit nothing. Falling back to the detector's theta
+                # (lightnet always gives 0.0) would embed an unrotated crop -- exactly
+                # the regression this model type exists to repair. A *predicted* 0.0 is
+                # valid; a *missing* one is not, so it must not be defaulted. Partial
+                # success is also rejected: silently dropping a detection is how
+                # annotations go missing.
+                theta_regressor = isinstance(orientation_model, WbiaOrientationModel)
+                wbia_orientation_results = None
+                if theta_regressor and filtered_bboxes:
+                    ori_bboxes = [bp.get('bbox', []) for bp in filtered_bboxes]
+                    try:
+                        wbia_orientation_results = await run_in_threadpool(
+                            orientation_model.predict_batch,
+                            image_bytes=image_bytes,
+                            bboxes=ori_bboxes,
+                        )
+                    except OrientationInferenceError as e:
+                        logger.error(f"Orientation failed; failing the request: {e}")
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Orientation model "
+                                   f"'{pipeline_request.orientation_model_id}' could not "
+                                   f"produce a trustworthy theta: {e}"
+                        )
+                    # Ordered 1:1 is load-bearing -- a misaligned row would attach one
+                    # bbox's theta to another's crop.
+                    if len(wbia_orientation_results) != len(filtered_bboxes):
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Orientation returned "
+                                   f"{len(wbia_orientation_results)} result(s) for "
+                                   f"{len(filtered_bboxes)} bbox(es)."
+                        )
+                    # Validate EVERY row here, not lazily inside the consumer loop.
+                    # Checking only the count and then dereferencing per-bbox would let
+                    # a malformed row N run classify/extract for rows 0..N-1 before the
+                    # request failed -- request-level fail-closed must mean no consumer
+                    # runs at all.
+                    for idx, ori in enumerate(wbia_orientation_results):
+                        if not isinstance(ori, dict):
+                            raise HTTPException(
+                                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                detail=f"Orientation result {idx} is not an object.")
+                        th_val = ori.get('theta')
+                        if not isinstance(th_val, (int, float)) or isinstance(th_val, bool) \
+                                or not math.isfinite(float(th_val)):
+                            raise HTTPException(
+                                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                detail=f"Orientation result {idx} has a non-finite or "
+                                       f"missing theta: {th_val!r}")
+                        eb = ori.get('effective_bbox')
+                        if (not isinstance(eb, (list, tuple)) or len(eb) != 4
+                                or not all(isinstance(v, int) and not isinstance(v, bool)
+                                           for v in eb)):
+                            raise HTTPException(
+                                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                detail=f"Orientation result {idx} has a malformed "
+                                       f"effective_bbox: {eb!r}")
 
-                extract_task = run_in_threadpool(
-                    extract_model.extract_embeddings,
-                    image_bytes=image_bytes,
-                    bbox=tuple(bbox_list),
-                    theta=theta
-                )
-                tasks.append(extract_task)
-                task_names.append('extract')
+                # Step 3: Run classification and extraction for each filtered bbox
+                pipeline_results = []
+                original_classify_results = []
+                original_extract_results = []
+                
+                for i, bbox_prediction in enumerate(filtered_bboxes):
+                    bbox_coords = bbox_prediction.get('bbox', [])
+                    if len(bbox_coords) != 4:
+                        logger.warning(f"Skipping bbox {i}: invalid coordinates {bbox_coords}")
+                        continue
+                    
+                    # YOLO already returns bbox in [x, y, width, height] format, no conversion needed
+                    x, y, width, height = bbox_coords
+                    bbox_list = [int(x), int(y), int(width), int(height)]
+                    theta = float(bbox_prediction.get('theta', 0.0))
+                    theta_source = 'detector'
+                    detector_bbox = list(bbox_coords)   # audit: what the detector said
 
-                if orientation_model and not theta_regressor:
-                    orientation_task = run_in_threadpool(
-                        orientation_model.predict,
+                    if wbia_orientation_results is not None:
+                        ori = wbia_orientation_results[i]
+                        theta = float(ori['theta'])
+                        theta_source = 'orientation'
+                        # effective_bbox is the slice orientation ACTUALLY used (NumPy
+                        # slicing does not clamp, and a degenerate crop falls back to
+                        # the full frame). classify, extract and the emitted result
+                        # must all use it, or theta describes a region other than the
+                        # crop it rotates.
+                        bbox_list = list(ori['effective_bbox'])
+                        bbox_coords = bbox_list
+                    elif bbox_list[2] <= 0 or bbox_list[3] <= 0:
+                        # Guard AFTER integerization: a raw width of 0.5 passes
+                        # `width <= 0` but int(0.5) == 0, so consumers would receive a
+                        # degenerate box. Only skip when orientation is NOT resolving
+                        # bboxes for us -- its degenerate-crop fallback needs to see these.
+                        logger.warning(f"Skipping bbox {i}: invalid dimensions "
+                                       f"width={width}, height={height} "
+                                       f"(integerized to {bbox_list[2]}x{bbox_list[3]})")
+                        continue
+
+                    # Run orientation, classification, and extraction in parallel
+                    tasks = []
+                    task_names = []
+
+                    classify_task = run_in_threadpool(
+                        classify_model.predict,
                         image_bytes=image_bytes,
                         bbox=bbox_list,
                         theta=theta
                     )
-                    tasks.append(orientation_task)
-                    task_names.append('orientation')
+                    tasks.append(classify_task)
+                    task_names.append('classify')
 
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-
-                # Unpack results, handling per-task failures
-                classify_result = results[0]
-                embeddings = results[1]
-                orientation_result = results[2] if len(results) > 2 else None
-
-                if isinstance(classify_result, Exception):
-                    logger.warning(f"Classification failed for bbox {i}: {classify_result}")
-                    classify_result = {}
-                if isinstance(embeddings, Exception):
-                    # Embedding is required by the Wildbook v2 response
-                    # contract (every result must carry a non-empty
-                    # `embedding` array). A null/missing embedding would
-                    # make the entire response invalid for v2 consumers,
-                    # so fail the request rather than emit a poisoned
-                    # success body. Classification/orientation can still
-                    # soft-fail because they are optional in the contract.
-                    logger.error(f"Extraction failed for bbox {i}: {embeddings}")
-                    raise HTTPException(
-                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                        detail=f"Embedding extraction failed for bbox {i}: {embeddings}"
+                    extract_task = run_in_threadpool(
+                        extract_model.extract_embeddings,
+                        image_bytes=image_bytes,
+                        bbox=tuple(bbox_list),
+                        theta=theta
                     )
-                if isinstance(orientation_result, Exception):
-                    logger.warning(f"Orientation failed for bbox {i}: {orientation_result}")
-                    orientation_result = None
+                    tasks.append(extract_task)
+                    task_names.append('extract')
 
-                embeddings_list = embeddings.tolist() if embeddings is not None else None
-                embeddings_shape = list(embeddings.shape) if embeddings is not None else None
+                    if orientation_model and not theta_regressor:
+                        orientation_task = run_in_threadpool(
+                            orientation_model.predict,
+                            image_bytes=image_bytes,
+                            bbox=bbox_list,
+                            theta=theta
+                        )
+                        tasks.append(orientation_task)
+                        task_names.append('orientation')
 
-                # Store original results
-                original_classify_results.append(classify_result)
-                original_extract_results.append({
-                    'embeddings': embeddings_list,
-                    'embeddings_shape': embeddings_shape,
-                    'bbox': bbox_list
-                })
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
 
-                # Extract the top classification result
-                top_classification = None
-                top_species = None
-                top_viewpoint = None
-                if isinstance(classify_result, dict) and 'predictions' in classify_result and classify_result['predictions']:
-                    top_class = classify_result['predictions'][0]
-                    top_classification = {
-                        'class': top_class.get('label'),
-                        'probability': top_class.get('probability'),
-                        'class_id': top_class.get('index')
-                    }
-                    top_species = top_class.get('species')
-                    top_viewpoint = top_class.get('viewpoint')
+                    # Unpack results, handling per-task failures
+                    classify_result = results[0]
+                    embeddings = results[1]
+                    orientation_result = results[2] if len(results) > 2 else None
 
-                # Extract orientation top prediction
-                top_orientation = None
-                if isinstance(orientation_result, dict) and 'predictions' in orientation_result:
-                    preds = orientation_result['predictions']
-                    if preds:
-                        top_orientation = {
-                            'label': preds[0].get('label'),
-                            'probability': preds[0].get('probability'),
-                            'class_id': preds[0].get('index')
+                    if isinstance(classify_result, Exception):
+                        logger.warning(f"Classification failed for bbox {i}: {classify_result}")
+                        classify_result = {}
+                    if isinstance(embeddings, Exception):
+                        # Embedding is required by the Wildbook v2 response
+                        # contract (every result must carry a non-empty
+                        # `embedding` array). A null/missing embedding would
+                        # make the entire response invalid for v2 consumers,
+                        # so fail the request rather than emit a poisoned
+                        # success body. Classification/orientation can still
+                        # soft-fail because they are optional in the contract.
+                        logger.error(f"Extraction failed for bbox {i}: {embeddings}")
+                        raise HTTPException(
+                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Embedding extraction failed for bbox {i}: {embeddings}"
+                        )
+                    if isinstance(orientation_result, Exception):
+                        logger.warning(f"Orientation failed for bbox {i}: {orientation_result}")
+                        orientation_result = None
+
+                    embeddings_list = embeddings.tolist() if embeddings is not None else None
+                    embeddings_shape = list(embeddings.shape) if embeddings is not None else None
+
+                    # Store original results
+                    original_classify_results.append(classify_result)
+                    original_extract_results.append({
+                        'embeddings': embeddings_list,
+                        'embeddings_shape': embeddings_shape,
+                        'bbox': bbox_list
+                    })
+
+                    # Extract the top classification result
+                    top_classification = None
+                    top_species = None
+                    top_viewpoint = None
+                    if isinstance(classify_result, dict) and 'predictions' in classify_result and classify_result['predictions']:
+                        top_class = classify_result['predictions'][0]
+                        top_classification = {
+                            'class': top_class.get('label'),
+                            'probability': top_class.get('probability'),
+                            'class_id': top_class.get('index')
                         }
+                        top_species = top_class.get('species')
+                        top_viewpoint = top_class.get('viewpoint')
 
-                # Flatten the embedding to a 1D list. MiewID returns a
-                # [1, D] tensor per crop; .tolist() gives [[d1, d2, ...]].
-                # Wildbook v2 expects a flat array of doubles directly on
-                # the result entry.
-                flat_embedding = None
-                if embeddings_list is not None:
-                    if embeddings_list and isinstance(embeddings_list[0], list):
-                        flat_embedding = embeddings_list[0]
-                    else:
-                        flat_embedding = embeddings_list
+                    # Extract orientation top prediction
+                    top_orientation = None
+                    if isinstance(orientation_result, dict) and 'predictions' in orientation_result:
+                        preds = orientation_result['predictions']
+                        if preds:
+                            top_orientation = {
+                                'label': preds[0].get('label'),
+                                'probability': preds[0].get('probability'),
+                                'class_id': preds[0].get('index')
+                            }
 
-                # Create clean pipeline result entry
-                bbox_result = {
-                    'bbox': bbox_coords,
-                    'detector_bbox': detector_bbox,
-                    'theta': theta,
-                    'theta_source': theta_source,
-                    'bbox_score': bbox_prediction.get('score'),
-                    'detection_class': bbox_prediction.get('class'),
-                    'detection_class_id': bbox_prediction.get('class_id'),
-                    'classification': top_classification,
-                    'embedding': flat_embedding,
-                    'embedding_shape': embeddings_shape,
-                    # Wildbook v2 contract: embedding_model_id +
-                    # embedding_model_version must live on each result so
-                    # the persisted Embedding row's (method, version) pair
-                    # matches what the matching code looks up later.
-                    'embedding_model_id': pipeline_request.extract_model_id,
-                    'embedding_model_version': extract_model_version,
+                    # Flatten the embedding to a 1D list. MiewID returns a
+                    # [1, D] tensor per crop; .tolist() gives [[d1, d2, ...]].
+                    # Wildbook v2 expects a flat array of doubles directly on
+                    # the result entry.
+                    flat_embedding = None
+                    if embeddings_list is not None:
+                        if embeddings_list and isinstance(embeddings_list[0], list):
+                            flat_embedding = embeddings_list[0]
+                        else:
+                            flat_embedding = embeddings_list
+
+                    # Create clean pipeline result entry
+                    bbox_result = {
+                        'bbox': bbox_coords,
+                        'detector_bbox': detector_bbox,
+                        'theta': theta,
+                        'theta_source': theta_source,
+                        'bbox_score': bbox_prediction.get('score'),
+                        'detection_class': bbox_prediction.get('class'),
+                        'detection_class_id': bbox_prediction.get('class_id'),
+                        'classification': top_classification,
+                        'embedding': flat_embedding,
+                        'embedding_shape': embeddings_shape,
+                        # Wildbook v2 contract: embedding_model_id +
+                        # embedding_model_version must live on each result so
+                        # the persisted Embedding row's (method, version) pair
+                        # matches what the matching code looks up later.
+                        'embedding_model_id': pipeline_request.extract_model_id,
+                        'embedding_model_version': extract_model_version,
+                    }
+                    if top_orientation is not None:
+                        bbox_result['orientation'] = top_orientation
+                    if top_species is not None:
+                        bbox_result['iaClass'] = top_species
+                    if top_viewpoint is not None:
+                        bbox_result['viewpoint'] = top_viewpoint
+
+                    pipeline_results.append(bbox_result)
+                
+                # Calculate total predictions based on format
+                total_predictions = 0
+                if 'bboxes' in predict_result:
+                    total_predictions = len(predict_result.get('bboxes', []))
+                elif 'predictions' in predict_result:
+                    total_predictions = len(predict_result.get('predictions', []))
+                
+                # Prepare final response.
+                #
+                # Wildbook v2 contract:
+                #   - top-level `success: True` (validated by MlServiceClient)
+                #   - top-level `results` array (renamed from pipeline_results)
+                # Both are required by validatePipelineResponse in MlServiceClient.
+                # `pipeline_results` is kept as an alias for one release so any
+                # in-flight non-Wildbook callers (test scripts, etc.) don't break.
+                final_result = {
+                    'success': True,
+                    'image_uri': sanitize_uri_for_response(pipeline_request.image_uri),
+                    'models_used': {
+                        'predict_model_id': pipeline_request.predict_model_id,
+                        'classify_model_id': pipeline_request.classify_model_id,
+                        'extract_model_id': pipeline_request.extract_model_id,
+                        **(({'orientation_model_id': pipeline_request.orientation_model_id}
+                            ) if pipeline_request.orientation_model_id else {})
+                    },
+                    'bbox_score_threshold': pipeline_request.bbox_score_threshold,
+                    'total_predictions': total_predictions,
+                    'filtered_predictions': len(filtered_bboxes),
+                    'results': pipeline_results,
+                    'pipeline_results': pipeline_results,
+                    'original_predict': predict_result,
+                    'original_classify': original_classify_results,
+                    'original_extract': original_extract_results
                 }
-                if top_orientation is not None:
-                    bbox_result['orientation'] = top_orientation
-                if top_species is not None:
-                    bbox_result['iaClass'] = top_species
-                if top_viewpoint is not None:
-                    bbox_result['viewpoint'] = top_viewpoint
-
-                pipeline_results.append(bbox_result)
+                
+                return final_result
             
-            # Calculate total predictions based on format
-            total_predictions = 0
-            if 'bboxes' in predict_result:
-                total_predictions = len(predict_result.get('bboxes', []))
-            elif 'predictions' in predict_result:
-                total_predictions = len(predict_result.get('predictions', []))
-            
-            # Prepare final response.
-            #
-            # Wildbook v2 contract:
-            #   - top-level `success: True` (validated by MlServiceClient)
-            #   - top-level `results` array (renamed from pipeline_results)
-            # Both are required by validatePipelineResponse in MlServiceClient.
-            # `pipeline_results` is kept as an alias for one release so any
-            # in-flight non-Wildbook callers (test scripts, etc.) don't break.
-            final_result = {
-                'success': True,
-                'image_uri': sanitize_uri_for_response(pipeline_request.image_uri),
-                'models_used': {
-                    'predict_model_id': pipeline_request.predict_model_id,
-                    'classify_model_id': pipeline_request.classify_model_id,
-                    'extract_model_id': pipeline_request.extract_model_id,
-                    **(({'orientation_model_id': pipeline_request.orientation_model_id}
-                        ) if pipeline_request.orientation_model_id else {})
-                },
-                'bbox_score_threshold': pipeline_request.bbox_score_threshold,
-                'total_predictions': total_predictions,
-                'filtered_predictions': len(filtered_bboxes),
-                'results': pipeline_results,
-                'pipeline_results': pipeline_results,
-                'original_predict': predict_result,
-                'original_classify': original_classify_results,
-                'original_extract': original_extract_results
-            }
-            
-            return final_result
-            
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Error downloading image: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Error downloading image: {str(e)}"
-            )
         except HTTPException:
             raise
         except Exception as e:

--- a/app/routers/predict_router.py
+++ b/app/routers/predict_router.py
@@ -1,13 +1,12 @@
 import logging
 from fastapi import APIRouter, HTTPException, Request, status, Depends
 from typing import Optional, Dict, Any, List
-import httpx
 import asyncio
 from pydantic import BaseModel, Field
 import json
 import os
 from app.models.model_handler import ModelHandler
-from app.utils.image_uri import resolve_image_uri, sanitize_uri_for_logging
+from app.utils.image_uri import fetch_image_for_request, admission_slot, sanitize_uri_for_logging
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
@@ -71,7 +70,7 @@ async def predict(
     Raises:
         HTTPException: If there's an error processing the request
     """
-    async with predict_semaphore:
+    async with admission_slot():
         try:
             # Get the model instance
             model = handler.get_model(prediction.model_id)
@@ -84,45 +83,34 @@ async def predict(
                         "available_models": available_models
                     }
                 )
-            
+
             # Resolve image bytes from URI (URL, data URI, or local path)
-            try:
-                image_bytes = await resolve_image_uri(prediction.image_uri)
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=str(e)
+            image_bytes = await fetch_image_for_request(prediction.image_uri)
+
+            async with predict_semaphore:
+                # Get model info for default parameters
+                model_info = handler.get_model_info(prediction.model_id)
+
+                # Prepare prediction parameters, overriding defaults with any provided parameters
+                predict_params = model_info['config'].copy()
+                if prediction.model_params:
+                    predict_params.update(prediction.model_params)
+
+                # Remove any parameters that shouldn't be passed to predict
+                predict_params.pop('model_path', None)
+                predict_params.pop('device', None)
+
+                # Run inference in a thread pool
+                result = await run_in_threadpool(
+                    model.predict,
+                    image_bytes=image_bytes,
+                    **predict_params
                 )
-            
-            # Get model info for default parameters
-            model_info = handler.get_model_info(prediction.model_id)
-            
-            # Prepare prediction parameters, overriding defaults with any provided parameters
-            predict_params = model_info['config'].copy()
-            if prediction.model_params:
-                predict_params.update(prediction.model_params)
-            
-            # Remove any parameters that shouldn't be passed to predict
-            predict_params.pop('model_path', None)
-            predict_params.pop('device', None)
-            
-            # Run inference in a thread pool
-            result = await run_in_threadpool(
-                model.predict,
-                image_bytes=image_bytes,
-                **predict_params
-            )
-            
-            # Add model_id to the result
-            result['model_id'] = prediction.model_id
-            return result
-            
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Error downloading image: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Error downloading image: {str(e)}"
-            )
+
+                # Add model_id to the result
+                result['model_id'] = prediction.model_id
+                return result
+
         except HTTPException:
             raise
         except Exception as e:

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -1,10 +1,15 @@
 """Utilities for resolving image URIs to bytes."""
 
+import asyncio
 import base64
+import logging
+import os
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 def is_data_uri(uri: str) -> bool:
@@ -59,3 +64,81 @@ async def resolve_image_uri(uri: str) -> bytes:
             raise ValueError(f"File not found: {uri}")
         with open(file_path, "rb") as f:
             return f.read()
+
+
+# --- Shared fetch state -----------------------------------------------------
+# One httpx client + one admission semaphore per worker process. Created
+# lazily (first request) or eagerly (app startup); asyncio primitives bind
+# to the running event loop, so tests reset between cases (see conftest).
+
+_client: Optional["httpx.AsyncClient"] = None
+_admission: Optional[asyncio.Semaphore] = None
+_settings: Optional[dict] = None
+
+
+def load_fetch_settings() -> dict:
+    return {
+        "connect_timeout_s": float(os.getenv("IMAGE_FETCH_CONNECT_TIMEOUT_S", "10")),
+        "read_timeout_s": float(os.getenv("IMAGE_FETCH_READ_TIMEOUT_S", "30")),
+        "total_deadline_s": float(os.getenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "60")),
+        "admission_limit": int(os.getenv("IMAGE_ADMISSION_LIMIT", "8")),
+        "admission_wait_s": float(os.getenv("IMAGE_ADMISSION_WAIT_S", "20")),
+        "max_image_bytes": int(os.getenv("IMAGE_FETCH_MAX_BYTES", "52428800")),
+        "max_pixels": int(os.getenv("IMAGE_MAX_PIXELS", "150000000")),
+    }
+
+
+async def _log_redirect_hop(response: httpx.Response) -> None:
+    if response.is_redirect:
+        logger.info(
+            "Image fetch redirect: %s -> %s",
+            response.request.url.host,
+            response.headers.get("location", "?"),
+        )
+
+
+def init_image_fetch(transport: Optional[httpx.AsyncBaseTransport] = None) -> None:
+    """Create the shared client + admission semaphore. Idempotent."""
+    global _client, _admission, _settings
+    if _client is not None:
+        return
+    _settings = load_fetch_settings()
+    _client = httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            connect=_settings["connect_timeout_s"],
+            read=_settings["read_timeout_s"],
+            write=10.0,
+            pool=None,  # admission semaphore keeps requests <= max_connections
+        ),
+        limits=httpx.Limits(
+            max_connections=_settings["admission_limit"],
+            max_keepalive_connections=4,
+        ),
+        follow_redirects=True,
+        max_redirects=3,
+        event_hooks={"response": [_log_redirect_hop]},
+        transport=transport,
+    )
+    _admission = asyncio.Semaphore(_settings["admission_limit"])
+
+
+async def shutdown_image_fetch() -> None:
+    global _client, _admission, _settings
+    if _client is not None:
+        await _client.aclose()
+    _client = None
+    _admission = None
+    _settings = None
+
+
+def reset_fetch_state_for_tests() -> None:
+    """Synchronous reset for test isolation (drops, doesn't close, the client)."""
+    global _client, _admission, _settings
+    _client = None
+    _admission = None
+    _settings = None
+
+
+def _ensure_initialized() -> None:
+    if _client is None:
+        init_image_fetch()

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -12,6 +12,14 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+class ImageTooLargeError(ValueError):
+    """Image exceeds IMAGE_FETCH_MAX_BYTES or IMAGE_MAX_PIXELS."""
+
+
+class EmptyImageError(ValueError):
+    """Upstream returned a successful but empty body."""
+
+
 def is_data_uri(uri: str) -> bool:
     return uri.startswith('data:')
 
@@ -44,6 +52,28 @@ def decode_data_uri(uri: str) -> bytes:
     return base64.b64decode(encoded, validate=True)
 
 
+async def _fetch_url_bytes(uri: str) -> bytes:
+    """Stream a URL through the shared client, enforcing the byte cap."""
+    max_bytes = _settings["max_image_bytes"]
+    async with _client.stream("GET", uri) as response:
+        response.raise_for_status()
+        declared = response.headers.get("content-length")
+        if declared is not None and declared.isdigit() and int(declared) > max_bytes:
+            raise ImageTooLargeError(
+                f"Declared content-length {declared} exceeds cap {max_bytes}")
+        chunks = []
+        size = 0
+        async for chunk in response.aiter_bytes():
+            size += len(chunk)
+            if size > max_bytes:
+                raise ImageTooLargeError(
+                    f"Body exceeded cap {max_bytes} bytes mid-stream")
+            chunks.append(chunk)
+        if size == 0:
+            raise EmptyImageError("Upstream returned an empty body")
+        return b"".join(chunks)
+
+
 async def resolve_image_uri(uri: str) -> bytes:
     """Resolve an image URI (URL, data URI, or local path) to raw bytes.
 
@@ -54,10 +84,9 @@ async def resolve_image_uri(uri: str) -> bytes:
     if is_data_uri(uri):
         return decode_data_uri(uri)
     elif uri.startswith(('http://', 'https://')):
-        async with httpx.AsyncClient() as client:
-            response = await client.get(uri)
-            response.raise_for_status()
-            return response.content
+        _ensure_initialized()
+        return await asyncio.wait_for(
+            _fetch_url_bytes(uri), timeout=_settings["total_deadline_s"])
     else:
         file_path = Path(uri)
         if not file_path.exists():

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -6,10 +6,13 @@ import io
 import logging
 import os
 import stat as stat_module
+import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional, Tuple
 
 import httpx
+from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
 from PIL import Image
 
@@ -206,3 +209,66 @@ def reset_fetch_state_for_tests() -> None:
 def _ensure_initialized() -> None:
     if _client is None:
         init_image_fetch()
+
+
+@asynccontextmanager
+async def admission_slot():
+    """Bounded admission: one slot per in-flight image request, held from
+    fetch start through inference end. 503 (retryable) if the wait exceeds
+    IMAGE_ADMISSION_WAIT_S."""
+    _ensure_initialized()
+    try:
+        await asyncio.wait_for(
+            _admission.acquire(), timeout=_settings["admission_wait_s"])
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=503,
+            detail="Service saturated: no admission slot available")
+    try:
+        yield
+    finally:
+        _admission.release()
+
+
+def _fail(status_code: int, uri: str, exc: Exception, started: float):
+    logger.warning(
+        "Image fetch failed (%d, %s, %.0f ms): %s",
+        status_code, type(exc).__name__, (time.monotonic() - started) * 1000,
+        sanitize_uri_for_logging(uri))
+    raise HTTPException(
+        status_code=status_code,
+        detail=f"Image fetch failed for {sanitize_uri_for_response(uri)}: "
+               f"{type(exc).__name__}")
+
+
+async def fetch_image_for_request(uri: str) -> bytes:
+    """Router entry point: resolve + header-check an image URI, mapping
+    every failure to the retry-ladder-correct HTTPException."""
+    started = time.monotonic()
+    try:
+        data = await resolve_image_uri(uri)
+        check_image_header(data)
+        logger.debug(
+            "Image fetched: %d bytes in %.0f ms from %s",
+            len(data), (time.monotonic() - started) * 1000,
+            sanitize_uri_for_logging(uri))
+        return data
+    except ValueError as e:               # incl. ImageTooLarge/Empty/bad header
+        _fail(400, uri, e, started)
+    except asyncio.TimeoutError as e:     # total deadline
+        _fail(504, uri, e, started)
+    except httpx.TimeoutException as e:   # connect/read/write/pool timeout
+        _fail(504, uri, e, started)
+    except httpx.TooManyRedirects as e:
+        _fail(400, uri, e, started)
+    except httpx.HTTPStatusError as e:
+        code = e.response.status_code
+        if code in (408, 429) or code >= 500:
+            _fail(502, uri, e, started)
+        _fail(400, uri, e, started)
+    except httpx.UnsupportedProtocol as e:
+        _fail(400, uri, e, started)
+    except httpx.InvalidURL as e:
+        _fail(400, uri, e, started)
+    except httpx.RequestError as e:       # DNS, refused, reset, TLS, decoding
+        _fail(502, uri, e, started)

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -2,12 +2,21 @@
 
 import asyncio
 import base64
+import io
 import logging
 import os
+import stat as stat_module
 from pathlib import Path
 from typing import Optional, Tuple
 
 import httpx
+from fastapi.concurrency import run_in_threadpool
+from PIL import Image
+
+# PIL's own decompression-bomb guard is replaced by the explicit
+# IMAGE_MAX_PIXELS check in check_image_header(), which runs before any
+# decode. Bytes never reach a decoder without passing that check.
+Image.MAX_IMAGE_PIXELS = None
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +58,26 @@ def decode_data_uri(uri: str) -> bytes:
     header, encoded = uri.split(',', 1)
     if ';base64' not in header:
         raise ValueError("Only base64-encoded data URIs are supported")
+    _ensure_initialized()
+    # 4/3 base64 expansion + header slack: reject before materializing
+    if len(encoded) > _settings["max_image_bytes"] * 4 // 3 + 8:
+        raise ImageTooLargeError("Encoded data URI exceeds size cap")
     return base64.b64decode(encoded, validate=True)
+
+
+def check_image_header(data: bytes) -> None:
+    """Reject bytes whose image header is unparseable or declares more
+    pixels than IMAGE_MAX_PIXELS. Parses the header only — no pixel decode."""
+    _ensure_initialized()
+    max_pixels = _settings["max_pixels"]
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            width, height = im.size
+    except Exception as e:
+        raise ValueError(f"Unrecognized image format: {e}")
+    if width * height > max_pixels:
+        raise ImageTooLargeError(
+            f"Image dimensions {width}x{height} exceed {max_pixels} pixel cap")
 
 
 async def _fetch_url_bytes(uri: str) -> bytes:
@@ -88,11 +116,18 @@ async def resolve_image_uri(uri: str) -> bytes:
         return await asyncio.wait_for(
             _fetch_url_bytes(uri), timeout=_settings["total_deadline_s"])
     else:
+        _ensure_initialized()
         file_path = Path(uri)
-        if not file_path.exists():
+        try:
+            st = os.stat(file_path)
+        except OSError:
             raise ValueError(f"File not found: {uri}")
-        with open(file_path, "rb") as f:
-            return f.read()
+        if not stat_module.S_ISREG(st.st_mode):
+            raise ValueError(f"Not a regular file: {uri}")
+        if st.st_size > _settings["max_image_bytes"]:
+            raise ImageTooLargeError(
+                f"File size {st.st_size} exceeds cap {_settings['max_image_bytes']}")
+        return await run_in_threadpool(file_path.read_bytes)
 
 
 # --- Shared fetch state -----------------------------------------------------

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -7,19 +7,21 @@ import logging
 import os
 import stat as stat_module
 import time
+import warnings
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import NoReturn, Optional, Tuple
 
 import httpx
 from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
 from PIL import Image
 
-# PIL's own decompression-bomb guard is replaced by the explicit
-# IMAGE_MAX_PIXELS check in check_image_header(), which runs before any
-# decode. Bytes never reach a decoder without passing that check.
-Image.MAX_IMAGE_PIXELS = None
+# check_image_header() enforces IMAGE_MAX_PIXELS with a friendly 400 before
+# any decode on the fetch_image_for_request path. Setting PIL's own guard to
+# the same cap (instead of disabling it) keeps a hard backstop on decode
+# paths that do not go through that helper (e.g. the wbia-compat router).
+Image.MAX_IMAGE_PIXELS = int(os.getenv("IMAGE_MAX_PIXELS", "150000000"))
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +76,16 @@ def check_image_header(data: bytes) -> None:
     _ensure_initialized()
     max_pixels = _settings["max_pixels"]
     try:
-        with Image.open(io.BytesIO(data)) as im:
-            width, height = im.size
+        with warnings.catch_warnings():
+            # PIL's own guard (set to the same cap, see module top) only
+            # warns at 1x and raises at 2x; suppress the warning here so our
+            # ImageTooLargeError stays the single user-visible error for
+            # both the 1x-2x and >2x cases.
+            warnings.simplefilter("ignore", Image.DecompressionBombWarning)
+            with Image.open(io.BytesIO(data)) as im:
+                width, height = im.size
+    except Image.DecompressionBombError as e:
+        raise ImageTooLargeError(f"Image header exceeds pixel cap: {e}")
     except Exception as e:
         raise ValueError(f"Unrecognized image format: {e}")
     if width * height > max_pixels:
@@ -170,6 +180,9 @@ def init_image_fetch(transport: Optional[httpx.AsyncBaseTransport] = None) -> No
     if _client is not None:
         return
     _settings = load_fetch_settings()
+    # pool=None on the client is safe only while the admission semaphore
+    # bounds concurrent requests to the pool size
+    assert _settings["admission_limit"] >= 1
     _client = httpx.AsyncClient(
         timeout=httpx.Timeout(
             connect=_settings["connect_timeout_s"],
@@ -230,7 +243,7 @@ async def admission_slot():
         _admission.release()
 
 
-def _fail(status_code: int, uri: str, exc: Exception, started: float):
+def _fail(status_code: int, uri: str, exc: Exception, started: float) -> NoReturn:
     logger.warning(
         "Image fetch failed (%d, %s, %.0f ms): %s",
         status_code, type(exc).__name__, (time.monotonic() - started) * 1000,
@@ -265,7 +278,8 @@ async def fetch_image_for_request(uri: str) -> bytes:
         code = e.response.status_code
         if code in (408, 429) or code >= 500:
             _fail(502, uri, e, started)
-        _fail(400, uri, e, started)
+        else:
+            _fail(400, uri, e, started)
     except httpx.UnsupportedProtocol as e:
         _fail(400, uri, e, started)
     except httpx.InvalidURL as e:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -22,6 +22,9 @@ services:
     #   IMAGE_FETCH_TOTAL_DEADLINE_S=60   IMAGE_ADMISSION_LIMIT=8
     #   IMAGE_ADMISSION_WAIT_S=20         IMAGE_FETCH_MAX_BYTES=52428800
     #   IMAGE_MAX_PIXELS=150000000        MAX_REQUEST_BODY_BYTES=4194304
+    #   OPENCV_IO_MAX_IMAGE_PIXELS  (cv2 decode backstop; cv2 default ~1GP)
+    # Data-URI installs: MAX_REQUEST_BODY_BYTES must cover base64 inflation
+    #   (~4/3x: a 50MB image needs ~67MB body cap).
     # Raise MAX_REQUEST_BODY_BYTES only for installations POSTing data URIs.
     # Recommended nginx back-stop in front of this service: client_max_body_size.
     # --limit-concurrency 32 (in-code default) 503s excess connections per worker.

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -17,6 +17,14 @@ services:
       - ultralytics_config:/root/.config/Ultralytics
     environment:
       - PYTHONPATH=/app
+    # Image-fetch resilience knobs (defaults in code; override via environment:)
+    #   IMAGE_FETCH_CONNECT_TIMEOUT_S=10  IMAGE_FETCH_READ_TIMEOUT_S=30
+    #   IMAGE_FETCH_TOTAL_DEADLINE_S=60   IMAGE_ADMISSION_LIMIT=8
+    #   IMAGE_ADMISSION_WAIT_S=20         IMAGE_FETCH_MAX_BYTES=52428800
+    #   IMAGE_MAX_PIXELS=150000000        MAX_REQUEST_BODY_BYTES=4194304
+    # Raise MAX_REQUEST_BODY_BYTES only for installations POSTing data URIs.
+    # Recommended nginx back-stop in front of this service: client_max_body_size.
+    # --limit-concurrency 32 (in-code default) 503s excess connections per worker.
     command: python3 -m app.main --host 0.0.0.0 --port 6050 --device ${DEVICE:-cuda} --workers ${WORKERS:-4}
     deploy:
       resources:

--- a/docs/plans/2026-08-14-image-fetch-resilience-design.md
+++ b/docs/plans/2026-08-14-image-fetch-resilience-design.md
@@ -1,0 +1,313 @@
+# Image-Fetch Resilience Design
+
+**Date:** 2026-08-14
+**Status:** Draft — revised after Codex adversarial review (rounds 1–3); pending user review
+**Motivation:** Production incident 2026-08-14: GiraffeSpotter stalled serving media,
+ml-service's image fetch hit httpx's unconfigured 5s default read timeout, the
+`httpx.ReadTimeout` escaped as a 500, and Wildbook's queue re-dispatched the job
+every ~6s (retry storm). Because the fetch runs inside the inference semaphore,
+each stalled fetch also held one of two per-worker inference slots, throttling
+every other installation sharing the service.
+
+## Goals
+
+1. A slow or stalled Wildbook must not consume inference slots, and must not
+   degrade service for other installations.
+2. Per-worker memory held by in-flight images is bounded by configuration, not
+   by upstream behavior.
+3. Image-fetch failures surface with HTTP semantics that drive Wildbook's retry
+   ladder correctly (retry transient failures with back-off; permanently drop
+   hopeless jobs).
+4. Every fetch failure logs the (sanitized) `image_uri` so incidents are
+   attributable to an asset and host.
+5. Timeouts and concurrency are tunable in production via environment variables.
+
+## Non-goals (with rationale)
+
+- **No push-model migration** (Wildbook POSTing image bytes). Pull stays
+  primary; base64 data URIs already work as a per-installation escape hatch.
+- **No per-host circuit breaker, no internal fetch retries.** Wildbook's
+  `MlServiceClient` failure ladder already retries 5xx/timeouts with back-off;
+  ml-service retrying on top multiplies load on a struggling Wildbook.
+- **No per-origin admission fairness.** Wildbook's FileQueue dispatches IA jobs
+  serially (~1 outstanding job per installation), so a single stalled
+  installation occupies only 1–2 admission slots of 8, and cannot starve the
+  others. **Assumption made explicit:** if Wildbook dispatch ever becomes
+  parallel per installation, add per-origin caps to the admission semaphore —
+  that is the designed extension point.
+- **No local-path root allowlist** (deferred hardening follow-up); local-path
+  resolution otherwise gains safety checks (§2).
+
+## Context (verified facts)
+
+- All four routers (`pipeline`, `predict`, `classify`, `extract`) call
+  `resolve_image_uri()` **inside** their `asyncio.Semaphore(2)` inference
+  guards, and catch only `ValueError` at the call site.
+- `resolve_image_uri()` creates a throwaway `httpx.AsyncClient()` per request
+  with default timeouts (5s), no redirect following, and full-body buffering.
+- Prod runs 4 uvicorn workers; all semaphores/clients are per-worker.
+- Wildbook sends `MediaAsset.webURL()` and waits connect 30s / read 120s. Its
+  failure ladder: timeout/408 → retry (no back-off increment); 429/5xx →
+  retry with back-off increment; other 4xx → non-retryable, job dropped.
+- httpx semantics that shape this design: `read` timeout is a **per-read
+  inactivity** timeout, not a total deadline; non-streaming requests buffer the
+  entire body before returning; `TooManyRedirects` and `DecodingError` are
+  `RequestError`s that are **not** `TransportError`s.
+
+## Design
+
+### 1. Shared fetch client, owned by the app lifespan
+
+One `httpx.AsyncClient` per worker, created in the FastAPI lifespan (post
+worker start, so no fork/loop hazards) and closed on shutdown. A small module
+(`app/utils/image_fetch.py` or extension of `image_uri.py`) holds it behind an
+accessor; tests replace it (and the semaphore, §2) per test via a fixture.
+
+Client configuration:
+
+- `timeout=httpx.Timeout(connect=CONNECT_T, read=READ_T, write=10.0, pool=None)`
+  (`pool=None` is safe because the admission semaphore keeps concurrent
+  requests ≤ `max_connections`; the invariant is asserted at startup).
+- `limits=httpx.Limits(max_connections=ADMISSION_LIMIT, max_keepalive_connections=4)`
+- `follow_redirects=True`, `max_redirects=3`. Cross-host redirects are allowed
+  (S3/CDN-backed asset stores legitimately redirect off-host) but each hop is
+  logged. **Explicit behavior change:** `resolve_image_uri()` today returns the
+  3xx body; after this change it follows up to 3 hops. Documented, tested.
+
+Environment variables (read once at startup):
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `IMAGE_FETCH_CONNECT_TIMEOUT_S` | `10` | TCP/TLS connect budget per attempt |
+| `IMAGE_FETCH_READ_TIMEOUT_S` | `30` | per-read inactivity budget |
+| `IMAGE_FETCH_TOTAL_DEADLINE_S` | `60` | hard wall-clock cap on the whole fetch (all redirects included) |
+| `IMAGE_ADMISSION_LIMIT` | `8` | in-flight requests per worker (fetch → inference end) |
+| `IMAGE_ADMISSION_WAIT_S` | `20` | max wait for an admission slot before returning 503 |
+| `IMAGE_FETCH_MAX_BYTES` | `52428800` (50 MB) | image size cap (streamed, data URI, and local file) |
+| `MAX_REQUEST_BODY_BYTES` | `4194304` (4 MB) | ASGI body cap; raise only on installations that POST data URIs |
+| `IMAGE_MAX_PIXELS` | `150000000` (150 MP) | decoded-dimension cap, checked from the image header before any decode |
+| uvicorn `--limit-concurrency` | `32` | server-level connection cap per worker; excess connections get 503 before their bodies are read |
+
+Budget check: total fetch deadline (60s) + inference must normally fit inside
+Wildbook's 120s read timeout; overrun degrades to Wildbook's own timeout,
+classified retryable-without-increment. Acceptable.
+
+### 2. Admission semaphore: one bound from fetch start to inference end
+
+`asyncio.Semaphore(IMAGE_ADMISSION_LIMIT)`, created in lifespan alongside the
+client (avoids loop-binding surprises), acquired at the top of each router
+handler and held until the response is built — covering fetch, the wait for an
+inference slot, and inference itself. The inner inference semaphores (2/worker)
+are unchanged.
+
+The acquire itself is bounded: `asyncio.wait_for(admission.acquire(),
+IMAGE_ADMISSION_WAIT_S)`; on timeout the request returns **503** (retryable
+with back-off on the Wildbook side). Without this bound, a worker whose eight
+slots are held by slow downloads would queue requests until Wildbook's own
+120s timeout fires — an unmapped, uninformative failure.
+
+Why one bound instead of a fetch-only semaphore: releasing after download
+would let completed multi-MB images pile up unboundedly while waiting for the
+2 inference slots. Holding admission through inference bounds worst-case
+per-worker image memory at roughly `2 × ADMISSION_LIMIT × IMAGE_FETCH_MAX_BYTES`
+— the factor 2 is honest accounting for the transient during `b"".join(chunks)`
+(chunk list + joined copy coexist briefly), and downstream decode (cv2/PIL)
+adds its own decoded-pixel allocation on the 2 inference slots. With defaults:
+2 × 8 × 50 MB = 800 MB ceiling per worker for **compressed bytes**, against
+typical real images of ≤15 MB. Decoded-pixel memory is bounded separately:
+before any bytes reach a model, the fetch helper reads the image header via
+PIL's lazy `Image.open` (parses dimensions without decoding pixel data) and
+rejects images whose `width × height > IMAGE_MAX_PIXELS` (default 150 MP,
+generous for camera/drone imagery) → 400 non-retryable — a decompression-bomb
+guard the current code lacks. cv2's `OPENCV_IO_MAX_IMAGE_PIXELS` env var is
+documented as a backstop for any decode path that bypasses the helper. A
+spooled-file handoff was considered and rejected: model decode needs
+contiguous bytes in RAM anyway, so spooling removes only the transient join
+copy at the cost of a changed downstream interface. The isolation property is
+unchanged: a stalled fetch holds an admission slot but **never** an inference
+slot, so inference stays saturated with work from healthy installations.
+
+The admission semaphore applies to **all** URI types (URL, data URI, local
+path) — queued data-URI requests hold memory too.
+
+**Data URIs.** FastAPI/Pydantic materializes the request body before any
+handler code runs, so handler-level checks cannot bound parse-time memory.
+Two controls close this:
+
+1. A small ASGI middleware enforces `MAX_REQUEST_BODY_BYTES` (default 4 MB —
+   ample for URL-based payloads) → **413** on violation. It rejects on the
+   `Content-Length` header when present and counts streamed bytes for chunked
+   bodies. Installations that POST data URIs raise the env var deliberately.
+2. In the handler, data URIs are rejected by **encoded length**
+   (`len(uri) > MAX_BYTES × 4/3 + header slack` → 400) *before* base64
+   decoding, so the decoder never materializes an over-cap payload.
+
+A proxy-level cap (nginx `client_max_body_size`) remains a recommended
+back-stop, documented in the deploy README, but the middleware makes the bound
+enforced rather than advisory. Aggregate parse-time memory (many concurrent
+bodies, each under the cap) is bounded server-side with uvicorn's native
+`--limit-concurrency 32` in the prod compose command — excess connections
+receive 503 before their bodies are read — giving an enforced pre-handler
+bound of `32 × MAX_REQUEST_BODY_BYTES = 128 MB` per worker. No custom ASGI
+admission gate is built; the native limit is sufficient and simpler.
+
+**Local paths** (dev/test usage; Wildbook never sends them): resolve via
+`os.stat` first — regular files only (reject FIFOs/devices, which could block
+indefinitely) and `st_size > IMAGE_FETCH_MAX_BYTES` → 400 **before** reading;
+then read in a threadpool (`run_in_threadpool`) so the event loop is never
+blocked by disk I/O. Restricting paths to an allowlisted root is a separate
+hardening follow-up, noted but out of scope here.
+
+### 3. Streaming fetch with size cap and total deadline
+
+The URL branch of `resolve_image_uri()` becomes:
+
+```python
+async def _fetch_url(uri: str) -> bytes:
+    async with client.stream("GET", uri) as response:
+        response.raise_for_status()
+        declared = response.headers.get("content-length")
+        if declared and int(declared) > MAX_BYTES:
+            raise ImageTooLarge(...)
+        chunks, size = [], 0
+        async for chunk in response.aiter_bytes():
+            size += len(chunk)
+            if size > MAX_BYTES:
+                raise ImageTooLarge(...)   # closes connection via context exit
+            chunks.append(chunk)
+        return b"".join(chunks)
+```
+
+wrapped in `asyncio.wait_for(_fetch_url(uri), IMAGE_FETCH_TOTAL_DEADLINE_S)`
+— the total deadline is what defeats slow-drip peers and redirect-chain
+budget multiplication; the per-read timeout just fails obvious stalls faster.
+Cancellation must release the admission permit (guaranteed by `async with` /
+`finally` structure) — covered by a dedicated test.
+
+The cap check counts **decoded** bytes (post `Content-Encoding`), which is the
+memory actually held.
+
+### 4. Error mapping
+
+New `async def fetch_image_for_request(uri: str) -> bytes` — the single entry
+point for routers. Maps failures to `HTTPException`, logging each with
+`sanitize_uri_for_logging(uri)`, elapsed time, and exception class:
+
+| Failure | Response | Wildbook's reaction |
+|---|---|---|
+| request body over `MAX_REQUEST_BODY_BYTES` (middleware) | 413 | drop job |
+| admission wait exceeded `IMAGE_ADMISSION_WAIT_S` | 503 | retry w/ back-off |
+| malformed/unsupported URL, invalid data URI, missing/irregular local file | 400 | drop job |
+| oversized (declared, streamed, encoded data URI, or local `st_size`) | 400 | drop job |
+| decoded dimensions over `IMAGE_MAX_PIXELS`, or unparseable image header | 400 | drop job |
+| empty body (0 bytes) | 400 | drop job |
+| redirect loop / too many redirects (`TooManyRedirects`) | 400 | drop job |
+| upstream 4xx **except 408, 429** (auth, gone, forbidden…) | 400 — permanent for an unchanged URI | drop job |
+| upstream 408, 429, any 5xx | 502 | retry w/ back-off |
+| total deadline exceeded (`asyncio.TimeoutError`) or httpx `TimeoutException` | 504 | retry w/ back-off |
+| `DecodingError` (bad content-encoding) | 502 | retry w/ back-off |
+| any other `httpx.RequestError` (DNS, refused, reset, TLS…) | 502 | retry w/ back-off |
+
+Rationale for upstream-4xx → 400: retrying an identical URI against a server
+that answered 401/403/404/415… only adds load; Wildbook logs the drop and the
+job is inspectable. 408/429 are the transient exceptions.
+
+`resolve_image_uri()` keeps raising raw exceptions (`ValueError` / httpx
+errors); only the mapping helper knows HTTP. Non-router callers see two
+intentional changes: redirect following (§1) and rejection of
+irregular/oversized local files (§2).
+
+### 5. Routers: admission outside, fetch before inference
+
+All four routers restructure identically:
+
+```
+POST /… → validate models             (no locks; registry reads only)
+        → acquire admission semaphore (held to end of request)
+        →   fetch_image_for_request() (streaming, deadline-capped)
+        →   acquire inference semaphore
+        →     inference
+        → response
+```
+
+In `pipeline_router` the model validation moves out of the semaphore block —
+safe, it only reads the in-memory model registry.
+
+### 6. Observability
+
+- Every fetch failure: one WARNING with mapped status, exception class,
+  elapsed ms, sanitized URI.
+- Every fetch success: DEBUG with elapsed ms and byte count (early signal of a
+  degrading Wildbook).
+- Every redirect hop: INFO with from-host → to-host.
+
+## Testing
+
+Unit tests (`tests/test_image_fetch.py`) with `httpx.MockTransport` injected
+through the lifespan/fixture hook; the fixture replaces **both** the client
+and the admission semaphore on the test's event loop:
+
+1. Mapping matrix: handler raises `httpx.ReadTimeout` directly (MockTransport
+   does not simulate timeouts by sleeping) → 504; `ConnectError` → 502;
+   upstream 500/429/408 → 502; upstream 404/403/401 → 400; `TooManyRedirects`
+   → 400; `DecodingError` → 502; empty body → 400.
+2. Size cap: declared oversize → 400 before body read; undeclared oversize →
+   400 mid-stream; oversized data URI rejected on encoded length before decode
+   → 400; local FIFO/oversized file → 400 without reading.
+2a. Body cap middleware: over-cap `Content-Length` → 413; over-cap chunked
+   body → 413. Admission wait timeout → 503 (semaphore pre-drained in test).
+2b. Pixel cap: valid JPEG header declaring > `IMAGE_MAX_PIXELS` → 400 without
+   full decode; bytes with no parseable image header (e.g. mp4) → 400.
+3. Total deadline: slow-drip handler (async generator yielding with delays) →
+   504 at the deadline, admission permit released after cancellation.
+4. Redirects: followed to 200 across hosts (≤3 hops); 4th hop → 400.
+5. Router level (extend existing per-router tests): each mapped
+   `HTTPException` passes through; a request failing at fetch never touches
+   the inference semaphore (instrumented semaphore).
+
+## Rollout
+
+1. Land on a branch; full test suite.
+2. Deploy to prod — all installations benefit; no Wildbook change required.
+3. Watch GiraffeSpotter: stalls should surface as 504s with the offending URI
+   logged; other installations' latency unaffected.
+4. Wildbook-side note (separate track): GiraffeSpotter's ~6s hot retry loop
+   suggests a build predating the current `MlServiceClient` failure ladder;
+   upgrading converts storms into back-off retries.
+
+## Relationship to existing work
+
+`fix/reject-undecodable-image-4xx` (undecodable/corrupt media → 4xx) is
+complementary: that branch handles bytes that arrive but can't decode; this
+design handles bytes that never arrive. The empty-body → 400 rule here closes
+the gap between them, and the header-based pixel cap (§2) additionally rejects
+non-image payloads (e.g. video files) at fetch time — overlapping that
+branch's goal from the other side; the two changes remain independent and
+compatible.
+
+## Review log
+
+- **Codex round 1:** 2 Critical, 5 Major, 1 Minor. Adopted: streaming size cap
+  (was post-read), total wall-clock deadline (was per-read only), admission
+  semaphore held through inference (was fetch-only), upstream-4xx → 400 (was
+  404/410 only), broadened `RequestError` mapping, lifespan-owned
+  client+semaphore, explicit redirect policy. Rejected: per-origin fairness
+  caps — Wildbook FileQueue dispatch is serial per installation (≤1–2
+  concurrent jobs each), so one stalled host cannot exhaust 8 admission slots;
+  documented as an assumption with a named extension point instead.
+- **Codex round 2:** 1 Critical, 3 Major; core structure (admission ordering,
+  streaming, deadline, mapping, redirect policy) endorsed; per-origin
+  rejection accepted conditional on the serial-dispatch contract. Adopted:
+  ASGI body-cap middleware + encoded-length data-URI rejection (was
+  advisory proxy note), bounded admission wait → 503 (was unbounded), honest
+  2× peak-memory accounting with cap lowered to 50 MB (spooled-file handoff
+  rejected — decode needs contiguous RAM regardless), local-path handling
+  specified (stat-first, regular files only, threadpool read; root allowlist
+  deferred as hardening follow-up). Rejected: admission-before-body-parse —
+  disproportionate given the 4 MB default body cap makes parse-time exposure
+  negligible.
+- **Codex round 3:** 1 Critical, 1 Major. Adopted (both, via the proportionate
+  variant): aggregate parse-time memory bounded with uvicorn's native
+  `--limit-concurrency 32` (Codex's own alternative to a custom ASGI admission
+  gate); decoded-pixel bound via header-parsed `IMAGE_MAX_PIXELS` check → 400
+  before any decode, with `OPENCV_IO_MAX_IMAGE_PIXELS` as documented backstop.

--- a/docs/plans/2026-08-14-image-fetch-resilience-design.md
+++ b/docs/plans/2026-08-14-image-fetch-resilience-design.md
@@ -222,8 +222,8 @@ irregular/oversized local files (§2).
 All four routers restructure identically:
 
 ```
-POST /… → validate models             (no locks; registry reads only)
-        → acquire admission semaphore (held to end of request)
+POST /… → acquire admission semaphore (held to end of request)
+        →   validate models           (registry reads only)
         →   fetch_image_for_request() (streaming, deadline-capped)
         →   acquire inference semaphore
         →     inference
@@ -232,6 +232,10 @@ POST /… → validate models             (no locks; registry reads only)
 
 In `pipeline_router` the model validation moves out of the semaphore block —
 safe, it only reads the in-memory model registry.
+
+Validation runs inside the admission slot; under full saturation a malformed
+request waits for a slot before failing — accepted for implementation
+simplicity.
 
 ### 6. Observability
 

--- a/docs/plans/2026-08-14-image-fetch-resilience-design.md
+++ b/docs/plans/2026-08-14-image-fetch-resilience-design.md
@@ -230,8 +230,9 @@ POST /… → acquire admission semaphore (held to end of request)
         → response
 ```
 
-In `pipeline_router` the model validation moves out of the semaphore block —
-safe, it only reads the in-memory model registry.
+In `pipeline_router` the model validation moves out of the *inference*
+semaphore — safe, it only reads the in-memory model registry — while running
+inside the admission slot, per the flow above.
 
 Validation runs inside the admission slot; under full saturation a malformed
 request waits for a slot before failing — accepted for implementation

--- a/docs/plans/2026-08-14-image-fetch-resilience-plan.md
+++ b/docs/plans/2026-08-14-image-fetch-resilience-plan.md
@@ -1,0 +1,1174 @@
+# Image-Fetch Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Slow/stalled Wildbook upstreams must not starve inference or blow memory; fetch failures must map to retry-ladder-correct status codes with the URI logged.
+
+**Architecture:** Per the approved spec `docs/plans/2026-08-14-image-fetch-resilience-design.md`. All fetch machinery lives in `app/utils/image_uri.py` (shared httpx client, admission semaphore, streaming fetch, size/pixel caps, error-mapping helper). A pure-ASGI body-cap middleware lives in `app/middleware.py`. The four image routers acquire an admission slot, fetch, then acquire their (unchanged) inference semaphore.
+
+**Tech Stack:** FastAPI 0.109, httpx 0.26 (`MockTransport` for tests), Pillow 10.1, pytest, Python 3.10.
+
+## Global Constraints
+
+- Python 3.10 syntax only (no `X | Y` in isinstance, `asyncio.wait_for` not `asyncio.timeout`).
+- All env defaults exactly as in the spec table: connect 10s, read 30s, total deadline 60s, admission 8, admission wait 20s, image cap 52428800, body cap 4194304, pixels 150000000, `--limit-concurrency` 32.
+- Status mapping exactly as the spec's table (400 permanent / 502 / 503 / 504 / 413).
+- Every fetch failure log line includes `sanitize_uri_for_logging(uri)`.
+- **Line endings:** after every Edit/Write to a tracked file run `perl -i -pe 's/\r\n/\n/g' <file>` and verify `grep -cP '\r$' <file>` prints 0 (WSL /mnt/c flips endings; CRLF diffs are unreviewable).
+- Run the full suite with `python3 -m pytest tests/ -q` before each commit; new failures in untouched tests are a stop-and-investigate signal.
+
+---
+
+### Task 1: Fetch state, settings, and lifecycle in `image_uri.py`
+
+**Files:**
+- Modify: `app/utils/image_uri.py` (append; keep all existing functions)
+- Create: `tests/conftest.py`
+- Test: `tests/test_image_fetch_lifecycle.py`
+
+**Interfaces:**
+- Produces: `load_fetch_settings() -> dict` (keys: `connect_timeout_s`, `read_timeout_s`, `total_deadline_s`, `admission_limit`, `admission_wait_s`, `max_image_bytes`, `max_pixels`); `init_image_fetch(transport=None) -> None` (sync); `shutdown_image_fetch() -> Coroutine`; `reset_fetch_state_for_tests() -> None`; module globals `_client`, `_admission`, `_settings`; `_ensure_initialized() -> None` (lazy init used by later tasks).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_image_fetch_lifecycle.py
+"""Lifecycle and settings tests for the shared image-fetch state."""
+import asyncio
+import httpx
+import pytest
+
+from app.utils import image_uri
+
+
+def test_load_fetch_settings_defaults():
+    s = image_uri.load_fetch_settings()
+    assert s["connect_timeout_s"] == 10.0
+    assert s["read_timeout_s"] == 30.0
+    assert s["total_deadline_s"] == 60.0
+    assert s["admission_limit"] == 8
+    assert s["admission_wait_s"] == 20.0
+    assert s["max_image_bytes"] == 52428800
+    assert s["max_pixels"] == 150000000
+
+
+def test_load_fetch_settings_env_override(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_READ_TIMEOUT_S", "5")
+    monkeypatch.setenv("IMAGE_ADMISSION_LIMIT", "2")
+    s = image_uri.load_fetch_settings()
+    assert s["read_timeout_s"] == 5.0
+    assert s["admission_limit"] == 2
+
+
+def test_init_creates_client_and_admission():
+    image_uri.init_image_fetch()
+    assert isinstance(image_uri._client, httpx.AsyncClient)
+    assert isinstance(image_uri._admission, asyncio.Semaphore)
+    # invariant asserted at init: pool max_connections == admission_limit
+    assert image_uri._settings["admission_limit"] == 8
+
+
+def test_init_accepts_mock_transport():
+    transport = httpx.MockTransport(lambda req: httpx.Response(200))
+    image_uri.init_image_fetch(transport=transport)
+    assert image_uri._client is not None
+
+
+def test_reset_clears_state():
+    image_uri.init_image_fetch()
+    image_uri.reset_fetch_state_for_tests()
+    assert image_uri._client is None
+    assert image_uri._admission is None
+```
+
+```python
+# tests/conftest.py
+"""Shared fixtures. The fetch state (httpx client + admission semaphore)
+binds to the event loop that first uses it; TestClient creates a fresh loop
+per instance, so state must be reset between tests to avoid cross-loop
+reuse of asyncio primitives."""
+import pytest
+
+from app.utils import image_uri
+
+
+@pytest.fixture(autouse=True)
+def _reset_image_fetch_state():
+    image_uri.reset_fetch_state_for_tests()
+    yield
+    image_uri.reset_fetch_state_for_tests()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_image_fetch_lifecycle.py -v`
+Expected: FAIL / ERROR with `AttributeError: module 'app.utils.image_uri' has no attribute 'load_fetch_settings'`
+
+- [ ] **Step 3: Implement**
+
+Append to `app/utils/image_uri.py` (and extend the imports at the top to `import asyncio`, `import logging`, `import os`, `from typing import Optional` — keep existing imports). Add `logger = logging.getLogger(__name__)` after the imports.
+
+```python
+# --- Shared fetch state -----------------------------------------------------
+# One httpx client + one admission semaphore per worker process. Created
+# lazily (first request) or eagerly (app startup); asyncio primitives bind
+# to the running event loop, so tests reset between cases (see conftest).
+
+_client: Optional["httpx.AsyncClient"] = None
+_admission: Optional[asyncio.Semaphore] = None
+_settings: Optional[dict] = None
+
+
+def load_fetch_settings() -> dict:
+    return {
+        "connect_timeout_s": float(os.getenv("IMAGE_FETCH_CONNECT_TIMEOUT_S", "10")),
+        "read_timeout_s": float(os.getenv("IMAGE_FETCH_READ_TIMEOUT_S", "30")),
+        "total_deadline_s": float(os.getenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "60")),
+        "admission_limit": int(os.getenv("IMAGE_ADMISSION_LIMIT", "8")),
+        "admission_wait_s": float(os.getenv("IMAGE_ADMISSION_WAIT_S", "20")),
+        "max_image_bytes": int(os.getenv("IMAGE_FETCH_MAX_BYTES", "52428800")),
+        "max_pixels": int(os.getenv("IMAGE_MAX_PIXELS", "150000000")),
+    }
+
+
+async def _log_redirect_hop(response: httpx.Response) -> None:
+    if response.is_redirect:
+        logger.info(
+            "Image fetch redirect: %s -> %s",
+            response.request.url.host,
+            response.headers.get("location", "?"),
+        )
+
+
+def init_image_fetch(transport: Optional[httpx.AsyncBaseTransport] = None) -> None:
+    """Create the shared client + admission semaphore. Idempotent."""
+    global _client, _admission, _settings
+    if _client is not None:
+        return
+    _settings = load_fetch_settings()
+    _client = httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            connect=_settings["connect_timeout_s"],
+            read=_settings["read_timeout_s"],
+            write=10.0,
+            pool=None,  # admission semaphore keeps requests <= max_connections
+        ),
+        limits=httpx.Limits(
+            max_connections=_settings["admission_limit"],
+            max_keepalive_connections=4,
+        ),
+        follow_redirects=True,
+        max_redirects=3,
+        event_hooks={"response": [_log_redirect_hop]},
+        transport=transport,
+    )
+    _admission = asyncio.Semaphore(_settings["admission_limit"])
+
+
+async def shutdown_image_fetch() -> None:
+    global _client, _admission, _settings
+    if _client is not None:
+        await _client.aclose()
+    _client = None
+    _admission = None
+    _settings = None
+
+
+def reset_fetch_state_for_tests() -> None:
+    """Synchronous reset for test isolation (drops, doesn't close, the client)."""
+    global _client, _admission, _settings
+    _client = None
+    _admission = None
+    _settings = None
+
+
+def _ensure_initialized() -> None:
+    if _client is None:
+        init_image_fetch()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_image_fetch_lifecycle.py -v` — Expected: all PASS.
+Then: `python3 -m pytest tests/ -q` — Expected: no new failures (conftest reset must not break existing tests).
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/utils/image_uri.py tests/conftest.py tests/test_image_fetch_lifecycle.py
+git add app/utils/image_uri.py tests/conftest.py tests/test_image_fetch_lifecycle.py
+git commit -m "feat: shared image-fetch client and admission state with env-tunable settings"
+```
+
+---
+
+### Task 2: Streaming URL fetch with size cap + total deadline
+
+**Files:**
+- Modify: `app/utils/image_uri.py` (replace the URL branch of `resolve_image_uri`; add `_fetch_url_bytes`, `ImageTooLargeError`, `EmptyImageError`)
+- Test: `tests/test_image_fetch_url.py`
+
+**Interfaces:**
+- Consumes: `_ensure_initialized`, `_client`, `_settings` (Task 1).
+- Produces: `ImageTooLargeError(ValueError)`, `EmptyImageError(ValueError)`; `resolve_image_uri(uri) -> bytes` now streams URLs through the shared client, raises `asyncio.TimeoutError` past the total deadline, keeps raising `ValueError`/httpx errors otherwise (contract unchanged for data URIs).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_image_fetch_url.py
+"""URL-branch tests for resolve_image_uri using httpx.MockTransport.
+
+MockTransport cannot simulate timeouts by sleeping; handlers raise
+httpx.ReadTimeout directly (per httpx docs)."""
+import asyncio
+import httpx
+import pytest
+
+from app.utils import image_uri
+
+
+def _init_with(handler):
+    image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+
+
+def test_url_fetch_returns_bytes():
+    _init_with(lambda req: httpx.Response(200, content=b"jpegbytes"))
+    result = asyncio.run(image_uri.resolve_image_uri("https://wb.example/img.jpg"))
+    assert result == b"jpegbytes"
+
+
+def test_url_fetch_declared_oversize_rejected_before_body():
+    _init_with(lambda req: httpx.Response(
+        200, headers={"content-length": str(60 * 1024 * 1024)}, content=b""))
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/big.jpg"))
+
+
+def test_url_fetch_undeclared_oversize_rejected_midstream(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "10")
+    _init_with(lambda req: httpx.Response(200, content=b"x" * 32))
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/liar.jpg"))
+
+
+def test_url_fetch_empty_body_rejected():
+    _init_with(lambda req: httpx.Response(200, content=b""))
+    with pytest.raises(image_uri.EmptyImageError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/empty.jpg"))
+
+
+def test_url_fetch_read_timeout_propagates():
+    def handler(req):
+        raise httpx.ReadTimeout("stalled", request=req)
+    _init_with(handler)
+    with pytest.raises(httpx.ReadTimeout):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/slow.jpg"))
+
+
+def test_url_fetch_total_deadline(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "0.05")
+
+    async def run():
+        async def slow_drip():
+            # slower than the deadline but each read under the read timeout
+            yield b"a"
+            await asyncio.sleep(0.2)
+            yield b"b"
+        def handler(req):
+            return httpx.Response(200, content=slow_drip())
+        image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+        with pytest.raises(asyncio.TimeoutError):
+            await image_uri.resolve_image_uri("https://wb.example/drip.jpg")
+    asyncio.run(run())
+
+
+def test_url_fetch_upstream_error_raises_status_error():
+    _init_with(lambda req: httpx.Response(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/oops.jpg"))
+
+
+def test_url_fetch_follows_redirect():
+    def handler(req):
+        if req.url.path == "/a":
+            return httpx.Response(302, headers={"location": "https://cdn.example/b"})
+        return httpx.Response(200, content=b"moved")
+    _init_with(handler)
+    result = asyncio.run(image_uri.resolve_image_uri("https://wb.example/a"))
+    assert result == b"moved"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_image_fetch_url.py -v`
+Expected: FAIL — `AttributeError: ... no attribute 'ImageTooLargeError'` and assertion failures (old code buffers via throwaway client).
+
+- [ ] **Step 3: Implement**
+
+In `app/utils/image_uri.py`: add the exception classes near the top, add `_fetch_url_bytes`, and change `resolve_image_uri`'s URL branch.
+
+```python
+class ImageTooLargeError(ValueError):
+    """Image exceeds IMAGE_FETCH_MAX_BYTES or IMAGE_MAX_PIXELS."""
+
+
+class EmptyImageError(ValueError):
+    """Upstream returned a successful but empty body."""
+
+
+async def _fetch_url_bytes(uri: str) -> bytes:
+    """Stream a URL through the shared client, enforcing the byte cap."""
+    max_bytes = _settings["max_image_bytes"]
+    async with _client.stream("GET", uri) as response:
+        response.raise_for_status()
+        declared = response.headers.get("content-length")
+        if declared is not None and declared.isdigit() and int(declared) > max_bytes:
+            raise ImageTooLargeError(
+                f"Declared content-length {declared} exceeds cap {max_bytes}")
+        chunks = []
+        size = 0
+        async for chunk in response.aiter_bytes():
+            size += len(chunk)
+            if size > max_bytes:
+                raise ImageTooLargeError(
+                    f"Body exceeded cap {max_bytes} bytes mid-stream")
+            chunks.append(chunk)
+        if size == 0:
+            raise EmptyImageError("Upstream returned an empty body")
+        return b"".join(chunks)
+```
+
+Replace the `elif uri.startswith(('http://', 'https://')):` block of `resolve_image_uri` with:
+
+```python
+    elif uri.startswith(('http://', 'https://')):
+        _ensure_initialized()
+        return await asyncio.wait_for(
+            _fetch_url_bytes(uri), timeout=_settings["total_deadline_s"])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_image_fetch_url.py tests/test_image_fetch_lifecycle.py -v` — Expected: all PASS.
+Then: `python3 -m pytest tests/ -q` — no new failures.
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/utils/image_uri.py tests/test_image_fetch_url.py
+git add app/utils/image_uri.py tests/test_image_fetch_url.py
+git commit -m "feat: streaming image fetch with size cap and total wall-clock deadline"
+```
+
+---
+
+### Task 3: Data-URI encoded-length check, local-path safety, pixel-header cap
+
+**Files:**
+- Modify: `app/utils/image_uri.py` (`decode_data_uri`, local-path branch of `resolve_image_uri`; add `check_image_header`)
+- Test: `tests/test_image_fetch_guards.py`
+
+**Interfaces:**
+- Consumes: `_settings`, `_ensure_initialized`, `ImageTooLargeError` (Tasks 1–2).
+- Produces: `check_image_header(data: bytes) -> None` (raises `ValueError` on unparseable header, `ImageTooLargeError` over pixel cap); `decode_data_uri` rejects over-cap encoded payloads; local paths are stat-checked (regular file, size) and read in a threadpool.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_image_fetch_guards.py
+"""Guards: encoded-length cap for data URIs, stat-first local files,
+header-parsed pixel cap."""
+import asyncio
+import base64
+import io
+import os
+import struct
+import zlib
+
+import pytest
+from PIL import Image
+
+from app.utils import image_uri
+
+# Valid 1x1 red PNG
+ONE_PX_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8"
+    "z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _png_with_dimensions(width, height):
+    """Craft a PNG whose IHDR declares width x height (header-only parse)."""
+    img = Image.new("RGB", (1, 1))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    data = bytearray(buf.getvalue())
+    # IHDR starts at byte 16: 4-byte width, 4-byte height (big-endian)
+    data[16:24] = struct.pack(">II", width, height)
+    # fix the IHDR CRC (bytes 29-33 cover chunk type+data at 12..29)
+    data[29:33] = struct.pack(">I", zlib.crc32(bytes(data[12:29])))
+    return bytes(data)
+
+
+def test_check_image_header_accepts_small_png():
+    image_uri.init_image_fetch()
+    image_uri.check_image_header(ONE_PX_PNG)  # must not raise
+
+
+def test_check_image_header_rejects_bomb():
+    image_uri.init_image_fetch()
+    bomb = _png_with_dimensions(20000, 20000)  # 400 MP > 150 MP cap
+    with pytest.raises(image_uri.ImageTooLargeError):
+        image_uri.check_image_header(bomb)
+
+
+def test_check_image_header_rejects_non_image():
+    image_uri.init_image_fetch()
+    with pytest.raises(ValueError):
+        image_uri.check_image_header(b"\x00\x00\x00\x18ftypmp42 not an image")
+
+
+def test_data_uri_encoded_length_cap(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "8")
+    image_uri.init_image_fetch()
+    big = "data:image/png;base64," + base64.b64encode(b"x" * 64).decode()
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri(big))
+
+
+def test_local_path_rejects_fifo(tmp_path):
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError):
+        asyncio.run(image_uri.resolve_image_uri(str(fifo)))
+
+
+def test_local_path_rejects_oversize(tmp_path, monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "4")
+    f = tmp_path / "big.jpg"
+    f.write_bytes(b"x" * 64)
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri(str(f)))
+
+
+def test_local_path_reads_regular_file(tmp_path):
+    f = tmp_path / "ok.png"
+    f.write_bytes(ONE_PX_PNG)
+    assert asyncio.run(image_uri.resolve_image_uri(str(f))) == ONE_PX_PNG
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_image_fetch_guards.py -v`
+Expected: FAIL — no `check_image_header`; FIFO test hangs are prevented because the current code `open()`s it only after `exists()`, so if this test hangs instead of failing, that confirms the defect — kill and proceed.
+
+- [ ] **Step 3: Implement**
+
+In `app/utils/image_uri.py`: add imports `import io`, `import stat as stat_module`, `from PIL import Image`, `from fastapi.concurrency import run_in_threadpool`. Immediately after the PIL import add:
+
+```python
+# PIL's own decompression-bomb guard is replaced by the explicit
+# IMAGE_MAX_PIXELS check in check_image_header(), which runs before any
+# decode. Bytes never reach a decoder without passing that check.
+Image.MAX_IMAGE_PIXELS = None
+```
+
+Add:
+
+```python
+def check_image_header(data: bytes) -> None:
+    """Reject bytes whose image header is unparseable or declares more
+    pixels than IMAGE_MAX_PIXELS. Parses the header only — no pixel decode."""
+    _ensure_initialized()
+    max_pixels = _settings["max_pixels"]
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            width, height = im.size
+    except Exception as e:
+        raise ValueError(f"Unrecognized image format: {e}")
+    if width * height > max_pixels:
+        raise ImageTooLargeError(
+            f"Image dimensions {width}x{height} exceed {max_pixels} pixel cap")
+```
+
+In `decode_data_uri`, after the base64 header check and before decoding, add (note `_ensure_initialized()` first):
+
+```python
+    _ensure_initialized()
+    # 4/3 base64 expansion + header slack: reject before materializing
+    if len(encoded) > _settings["max_image_bytes"] * 4 // 3 + 8:
+        raise ImageTooLargeError("Encoded data URI exceeds size cap")
+```
+
+Replace the local-path `else:` branch of `resolve_image_uri` with:
+
+```python
+    else:
+        _ensure_initialized()
+        file_path = Path(uri)
+        try:
+            st = os.stat(file_path)
+        except OSError:
+            raise ValueError(f"File not found: {uri}")
+        if not stat_module.S_ISREG(st.st_mode):
+            raise ValueError(f"Not a regular file: {uri}")
+        if st.st_size > _settings["max_image_bytes"]:
+            raise ImageTooLargeError(
+                f"File size {st.st_size} exceeds cap {_settings['max_image_bytes']}")
+        return await run_in_threadpool(file_path.read_bytes)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_image_fetch_guards.py -v` — all PASS.
+Then: `python3 -m pytest tests/ -q` — no new failures.
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/utils/image_uri.py tests/test_image_fetch_guards.py
+git add app/utils/image_uri.py tests/test_image_fetch_guards.py
+git commit -m "feat: pixel-header cap, encoded data-URI cap, stat-first local reads"
+```
+
+---
+
+### Task 4: Error-mapping helper and bounded admission slot
+
+**Files:**
+- Modify: `app/utils/image_uri.py`
+- Test: `tests/test_image_fetch_mapping.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces: `fetch_image_for_request(uri: str) -> bytes` (raises `fastapi.HTTPException` per the spec's mapping table, logs every failure with sanitized URI + elapsed ms); `admission_slot()` async context manager (403→ no; raises `HTTPException(503)` when the slot wait exceeds `IMAGE_ADMISSION_WAIT_S`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_image_fetch_mapping.py
+"""fetch_image_for_request must map every failure class to the spec's
+status code, and admission_slot must 503 on wait timeout."""
+import asyncio
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.utils import image_uri
+from tests.test_image_fetch_guards import ONE_PX_PNG
+
+
+def _status_for(handler):
+    image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(image_uri.fetch_image_for_request("https://wb.example/x.jpg"))
+    return exc.value.status_code
+
+
+def test_success_returns_bytes():
+    image_uri.init_image_fetch(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, content=ONE_PX_PNG)))
+    data = asyncio.run(image_uri.fetch_image_for_request("https://wb.example/ok.png"))
+    assert data == ONE_PX_PNG
+
+
+def test_read_timeout_maps_504():
+    def h(req):
+        raise httpx.ReadTimeout("stall", request=req)
+    assert _status_for(h) == 504
+
+
+def test_connect_error_maps_502():
+    def h(req):
+        raise httpx.ConnectError("refused", request=req)
+    assert _status_for(h) == 502
+
+
+def test_upstream_500_maps_502():
+    assert _status_for(lambda r: httpx.Response(500)) == 502
+
+
+def test_upstream_429_maps_502():
+    assert _status_for(lambda r: httpx.Response(429)) == 502
+
+
+def test_upstream_408_maps_502():
+    assert _status_for(lambda r: httpx.Response(408)) == 502
+
+
+@pytest.mark.parametrize("code", [401, 403, 404, 410, 415])
+def test_upstream_permanent_4xx_maps_400(code):
+    assert _status_for(lambda r, c=code: httpx.Response(c)) == 400
+
+
+def test_too_many_redirects_maps_400():
+    def h(req):
+        return httpx.Response(302, headers={"location": str(req.url)})
+    assert _status_for(h) == 400
+
+
+def test_decoding_error_maps_502():
+    def h(req):
+        raise httpx.DecodingError("bad encoding", request=req)
+    assert _status_for(h) == 502
+
+
+def test_unparseable_image_maps_400():
+    assert _status_for(lambda r: httpx.Response(200, content=b"mp4junk" * 4)) == 400
+
+
+def test_invalid_data_uri_maps_400():
+    image_uri.init_image_fetch()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(image_uri.fetch_image_for_request("data:image/png;base64"))
+    assert exc.value.status_code == 400
+
+
+def test_total_deadline_maps_504(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "0.05")
+
+    async def run():
+        async def drip():
+            yield b"a"
+            await asyncio.sleep(0.2)
+            yield b"b"
+        image_uri.init_image_fetch(
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, content=drip())))
+        with pytest.raises(HTTPException) as exc:
+            await image_uri.fetch_image_for_request("https://wb.example/drip.jpg")
+        assert exc.value.status_code == 504
+    asyncio.run(run())
+
+
+def test_admission_slot_503_on_wait_timeout(monkeypatch):
+    monkeypatch.setenv("IMAGE_ADMISSION_LIMIT", "1")
+    monkeypatch.setenv("IMAGE_ADMISSION_WAIT_S", "0.05")
+
+    async def run():
+        image_uri.init_image_fetch()
+        async with image_uri.admission_slot():
+            with pytest.raises(HTTPException) as exc:
+                async with image_uri.admission_slot():
+                    pass
+            assert exc.value.status_code == 503
+    asyncio.run(run())
+
+
+def test_admission_slot_releases_on_exception():
+    async def run():
+        image_uri.init_image_fetch()
+        with pytest.raises(RuntimeError):
+            async with image_uri.admission_slot():
+                raise RuntimeError("boom")
+        # slot must be free again
+        async with image_uri.admission_slot():
+            pass
+    asyncio.run(run())
+
+
+def test_failure_log_contains_sanitized_uri(caplog):
+    def h(req):
+        raise httpx.ConnectError("refused", request=req)
+    image_uri.init_image_fetch(transport=httpx.MockTransport(h))
+    with pytest.raises(HTTPException):
+        asyncio.run(image_uri.fetch_image_for_request("https://wb.example/y.jpg"))
+    assert any("https://wb.example/y.jpg" in r.message for r in caplog.records)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_image_fetch_mapping.py -v`
+Expected: FAIL — `no attribute 'fetch_image_for_request'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `app/utils/image_uri.py` (add `import time` and `from contextlib import asynccontextmanager`; import `HTTPException` from fastapi):
+
+```python
+@asynccontextmanager
+async def admission_slot():
+    """Bounded admission: one slot per in-flight image request, held from
+    fetch start through inference end. 503 (retryable) if the wait exceeds
+    IMAGE_ADMISSION_WAIT_S."""
+    _ensure_initialized()
+    try:
+        await asyncio.wait_for(
+            _admission.acquire(), timeout=_settings["admission_wait_s"])
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=503,
+            detail="Service saturated: no admission slot available")
+    try:
+        yield
+    finally:
+        _admission.release()
+
+
+def _fail(status_code: int, uri: str, exc: Exception, started: float):
+    logger.warning(
+        "Image fetch failed (%d, %s, %.0f ms): %s",
+        status_code, type(exc).__name__, (time.monotonic() - started) * 1000,
+        sanitize_uri_for_logging(uri))
+    raise HTTPException(
+        status_code=status_code,
+        detail=f"Image fetch failed for {sanitize_uri_for_response(uri)}: "
+               f"{type(exc).__name__}")
+
+
+async def fetch_image_for_request(uri: str) -> bytes:
+    """Router entry point: resolve + header-check an image URI, mapping
+    every failure to the retry-ladder-correct HTTPException."""
+    started = time.monotonic()
+    try:
+        data = await resolve_image_uri(uri)
+        check_image_header(data)
+        logger.debug(
+            "Image fetched: %d bytes in %.0f ms from %s",
+            len(data), (time.monotonic() - started) * 1000,
+            sanitize_uri_for_logging(uri))
+        return data
+    except ValueError as e:               # incl. ImageTooLarge/Empty/bad header
+        _fail(400, uri, e, started)
+    except asyncio.TimeoutError as e:     # total deadline
+        _fail(504, uri, e, started)
+    except httpx.TimeoutException as e:   # connect/read/write/pool timeout
+        _fail(504, uri, e, started)
+    except httpx.TooManyRedirects as e:
+        _fail(400, uri, e, started)
+    except httpx.HTTPStatusError as e:
+        code = e.response.status_code
+        if code in (408, 429) or code >= 500:
+            _fail(502, uri, e, started)
+        _fail(400, uri, e, started)
+    except httpx.UnsupportedProtocol as e:
+        _fail(400, uri, e, started)
+    except httpx.InvalidURL as e:
+        _fail(400, uri, e, started)
+    except httpx.RequestError as e:       # DNS, refused, reset, TLS, decoding
+        _fail(502, uri, e, started)
+```
+
+Exception-order constraint (do not reorder): `TimeoutException`, `TooManyRedirects`, `UnsupportedProtocol` are all `RequestError` subclasses — the generic `RequestError` catch must stay last. `InvalidURL` is NOT a `RequestError` in httpx 0.26 but is caught explicitly for safety.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_image_fetch_mapping.py -v` — all PASS.
+Then: `python3 -m pytest tests/ -q` — no new failures.
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/utils/image_uri.py tests/test_image_fetch_mapping.py
+git add app/utils/image_uri.py tests/test_image_fetch_mapping.py
+git commit -m "feat: retry-ladder error mapping and bounded admission slots"
+```
+
+---
+
+### Task 5: Body-cap ASGI middleware
+
+**Files:**
+- Create: `app/middleware.py`
+- Test: `tests/test_body_limit_middleware.py`
+
+**Interfaces:**
+- Produces: `BodyLimitMiddleware(app, max_bytes: int)` — pure ASGI; 413 on over-cap `Content-Length` or over-cap streamed body. Wired into the app in Task 7.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_body_limit_middleware.py
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware import BodyLimitMiddleware
+
+
+def _make_app(max_bytes=64):
+    app = FastAPI()
+    app.add_middleware(BodyLimitMiddleware, max_bytes=max_bytes)
+
+    @app.post("/echo")
+    async def echo(payload: dict):
+        return {"n": len(str(payload))}
+    return TestClient(app)
+
+
+def test_small_body_passes():
+    client = _make_app()
+    r = client.post("/echo", json={"a": 1})
+    assert r.status_code == 200
+
+
+def test_oversize_content_length_413():
+    client = _make_app(max_bytes=8)
+    r = client.post("/echo", json={"key": "value-far-over-eight-bytes"})
+    assert r.status_code == 413
+
+
+def test_oversize_chunked_body_413():
+    client = _make_app(max_bytes=8)
+
+    def gen():
+        yield b'{"key": "'
+        yield b"x" * 32
+        yield b'"}'
+    r = client.post("/echo", content=gen(),
+                    headers={"content-type": "application/json"})
+    assert r.status_code == 413
+
+
+def test_non_http_scope_passthrough():
+    # middleware must not touch lifespan scopes: app startup succeeding
+    # under TestClient's context manager proves it
+    with _make_app() as client:
+        assert client.post("/echo", json={"a": 1}).status_code == 200
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_body_limit_middleware.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.middleware'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# app/middleware.py
+"""Pure-ASGI request-body cap.
+
+Bounds per-request parse-time memory: FastAPI/Pydantic materializes the
+whole body before route handlers run, so the cap must sit below them.
+Aggregate concurrency is bounded separately by uvicorn --limit-concurrency."""
+
+
+class BodyLimitMiddleware:
+    def __init__(self, app, max_bytes: int):
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        declared = headers.get(b"content-length")
+        if declared is not None and declared.isdigit() and int(declared) > self.max_bytes:
+            await self._reject(send)
+            return
+
+        received = 0
+        response_started = False
+
+        async def counting_receive():
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    raise _BodyTooLarge()
+            return message
+
+        async def tracking_send(message):
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, counting_receive, tracking_send)
+        except _BodyTooLarge:
+            if not response_started:
+                await self._reject(send)
+            # else: response already in flight; connection ends here
+
+    @staticmethod
+    async def _reject(send):
+        body = b'{"detail":"Request body too large"}'
+        await send({
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})
+
+
+class _BodyTooLarge(Exception):
+    pass
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_body_limit_middleware.py -v` — all PASS.
+Then: `python3 -m pytest tests/ -q` — no new failures.
+
+- [ ] **Step 5: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/middleware.py tests/test_body_limit_middleware.py
+git add app/middleware.py tests/test_body_limit_middleware.py
+git commit -m "feat: ASGI body-size cap middleware (413 over MAX_REQUEST_BODY_BYTES)"
+```
+
+---
+
+### Task 6: Router integration (pipeline, predict, classify, extract)
+
+**Files:**
+- Modify: `app/routers/pipeline_router.py`, `app/routers/predict_router.py`, `app/routers/classify_router.py`, `app/routers/extract_router.py`
+- Modify: `tests/test_pipeline_router_classifier.py`, `tests/test_pipeline_router_theta.py`, `tests/test_pipeline_router_sentinel_species.py` (replace truncated data-URI payloads)
+- Test: `tests/test_router_fetch_isolation.py`
+
+**Interfaces:**
+- Consumes: `fetch_image_for_request`, `admission_slot` (Task 4).
+- Produces: request flow `admission_slot → validate → fetch → inference semaphore → inference` in all four routers.
+
+**The identical restructuring, applied to each router** (shown for pipeline; predict/classify/extract are the same moves on their own semaphore and validation blocks):
+
+1. Change the import line to `from app.utils.image_uri import fetch_image_for_request, admission_slot, sanitize_uri_for_response, sanitize_uri_for_logging` (keep only names the file still uses; drop `resolve_image_uri`).
+2. Replace `async with pipeline_semaphore:` (the whole-handler guard) with `async with admission_slot():`.
+3. Replace the fetch block
+
+```python
+            try:
+                image_bytes = await resolve_image_uri(pipeline_request.image_uri)
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(e)
+                )
+```
+
+with
+
+```python
+            image_bytes = await fetch_image_for_request(pipeline_request.image_uri)
+```
+
+(In classify/extract also delete the dead `with open(file_path, "rb") as f:` remnant lines directly below the old block.)
+
+4. Immediately after the fetch line, open the inference guard and indent everything from the first model call to the `return` one level into it:
+
+```python
+            async with pipeline_semaphore:
+                ...prediction / classification / extraction / response build...
+```
+
+The inference semaphore now wraps only model work; validation and fetch run before it. The `try/except` skeleton of each handler stays where it is (inside `admission_slot()`), so `HTTPException`s from the helper pass through the existing `except HTTPException: raise`.
+
+5. In `pipeline_router.py` delete the now-dead upstream-download handler (the fetch helper maps those):
+
+```python
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Error downloading image: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Error downloading image: {str(e)}"
+            )
+```
+
+Remove the same `except httpx.HTTPStatusError` block from classify/extract/predict if present, and drop each file's `import httpx` if nothing else in the file uses it.
+
+- [ ] **Step 1: Update existing test payloads (they will otherwise fail the new header check)**
+
+In `tests/test_pipeline_router_classifier.py`, `tests/test_pipeline_router_theta.py`, `tests/test_pipeline_router_sentinel_species.py`, replace every truncated payload — both `"data:image/png;base64,iVBORw0KGgo="` and `"data:image/jpeg;base64,/9j/4AAQSkZJRg=="` — with this valid 1×1 PNG data URI (define once per file as `VALID_PNG_DATA_URI` and reference it):
+
+```python
+VALID_PNG_DATA_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+```
+
+- [ ] **Step 2: Write the failing isolation test**
+
+```python
+# tests/test_router_fetch_isolation.py
+"""A request that fails at fetch must never touch the inference semaphore,
+and mapped statuses must pass through the router unchanged."""
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.routers import pipeline_router
+from app.utils import image_uri
+
+
+class SpySemaphore:
+    def __init__(self):
+        self.acquired = False
+
+    async def __aenter__(self):
+        self.acquired = True
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _client(monkeypatch, spy):
+    monkeypatch.setattr(pipeline_router, "pipeline_semaphore", spy)
+    app = FastAPI()
+    app.include_router(pipeline_router.router)
+    handler = MagicMock()
+    handler.get_model.return_value = MagicMock()
+    handler.get_model_info.return_value = {"config": {}}
+    handler.list_models.return_value = {}
+    app.state.model_handler = handler
+    return TestClient(app)
+
+
+PAYLOAD = {
+    "predict_model_id": "p", "classify_model_id": "c",
+    "extract_model_id": "e", "image_uri": "https://wb.example/img.jpg",
+}
+
+
+@pytest.mark.parametrize("code", [400, 502, 503, 504])
+def test_fetch_failure_status_passes_through_and_skips_inference(
+        monkeypatch, code):
+    spy = SpySemaphore()
+
+    async def failing_fetch(uri):
+        raise HTTPException(status_code=code, detail="mapped upstream failure")
+    monkeypatch.setattr(pipeline_router, "fetch_image_for_request", failing_fetch)
+    # model-type validation must pass so we reach the fetch
+    monkeypatch.setattr(pipeline_router, "isinstance",
+                        lambda obj, cls: True, raising=False)
+
+    client = _client(monkeypatch, spy)
+    r = client.post("/pipeline/", json=PAYLOAD)
+    assert r.status_code == code
+    assert spy.acquired is False
+```
+
+(If patching `isinstance` proves brittle, instead build the handler mocks with `MagicMock(spec=...)` real model classes exactly as `tests/test_pipeline_router_classifier.py` does — copy its `_make_app_with_models` and pass the spy semaphore.)
+
+- [ ] **Step 3: Run tests to verify current state fails**
+
+Run: `python3 -m pytest tests/test_router_fetch_isolation.py -v`
+Expected: FAIL — `AttributeError: ... no attribute 'fetch_image_for_request'` on the router module (not yet imported there).
+
+- [ ] **Step 4: Apply the restructuring to all four routers** (moves 1–5 above, per router)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all PASS — including the updated payload tests and the isolation test. Investigate any failure before proceeding; the most likely causes are (a) a payload still using a truncated data URI, (b) an indentation slip while inserting the inference guard.
+
+- [ ] **Step 6: Normalize line endings and commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/routers/pipeline_router.py app/routers/predict_router.py \
+  app/routers/classify_router.py app/routers/extract_router.py \
+  tests/test_pipeline_router_classifier.py tests/test_pipeline_router_theta.py \
+  tests/test_pipeline_router_sentinel_species.py tests/test_router_fetch_isolation.py
+git add -A app/routers tests
+git commit -m "feat: admission-gated fetch decoupled from inference semaphores in all image routers"
+```
+
+---
+
+### Task 7: App wiring, server concurrency limit, docs
+
+**Files:**
+- Modify: `app/main.py`
+- Modify: `docker/docker-compose.prod.yml` (comment block only)
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `init_image_fetch`, `shutdown_image_fetch` (Task 1), `BodyLimitMiddleware` (Task 5).
+
+- [ ] **Step 1: Wire startup/shutdown and middleware in `app/main.py`**
+
+After `app = FastAPI()` add:
+
+```python
+from app.middleware import BodyLimitMiddleware
+from app.utils import image_uri
+
+MAX_REQUEST_BODY_BYTES = int(os.getenv("MAX_REQUEST_BODY_BYTES", "4194304"))
+app.add_middleware(BodyLimitMiddleware, max_bytes=MAX_REQUEST_BODY_BYTES)
+```
+
+Inside the existing `startup_event()` (first line of the body):
+
+```python
+    image_uri.init_image_fetch()
+```
+
+Inside the existing `shutdown_event()` (first line of the body):
+
+```python
+    await image_uri.shutdown_image_fetch()
+```
+
+Add the CLI arg next to the existing ones and pass it to uvicorn:
+
+```python
+parser.add_argument('--limit-concurrency', type=int, default=32,
+                   help='Max concurrent connections per worker; excess get 503 '
+                        'before their bodies are read (bounds parse-time memory)')
+```
+
+```python
+    uvicorn.run("app.main:app", host=args.host, port=args.port,
+               reload=args.reload, workers=args.workers,
+               limit_concurrency=args.limit_concurrency)
+```
+
+- [ ] **Step 2: Verify the app boots and the suite passes**
+
+Run: `python3 -c "import app.main" && python3 -m pytest tests/ -q`
+Expected: import succeeds (argparse tolerates no args), all tests PASS.
+
+- [ ] **Step 3: Document the knobs in `docker/docker-compose.prod.yml`**
+
+Add directly above the `command:` line (comments only — defaults are in code):
+
+```yaml
+    # Image-fetch resilience knobs (defaults in code; override via environment:)
+    #   IMAGE_FETCH_CONNECT_TIMEOUT_S=10  IMAGE_FETCH_READ_TIMEOUT_S=30
+    #   IMAGE_FETCH_TOTAL_DEADLINE_S=60   IMAGE_ADMISSION_LIMIT=8
+    #   IMAGE_ADMISSION_WAIT_S=20         IMAGE_FETCH_MAX_BYTES=52428800
+    #   IMAGE_MAX_PIXELS=150000000        MAX_REQUEST_BODY_BYTES=4194304
+    # Raise MAX_REQUEST_BODY_BYTES only for installations POSTing data URIs.
+    # Recommended nginx back-stop in front of this service: client_max_body_size.
+    # --limit-concurrency 32 (in-code default) 503s excess connections per worker.
+```
+
+- [ ] **Step 4: Update `CHANGELOG.md`**
+
+Add under a new `## [Unreleased]`-style entry at the top, matching the file's existing format:
+
+```markdown
+- Image-fetch resilience (design: docs/plans/2026-08-14-image-fetch-resilience-design.md):
+  image downloads now use a shared client with explicit timeouts and a 60s total
+  deadline, run outside the inference semaphores behind a bounded admission gate,
+  stream with a 50 MB cap and 150 MP header check, and map failures to
+  retry-ladder-correct statuses (504/502 retryable, 400 permanent, 503 saturated,
+  413 oversized body). Fixes the GiraffeSpotter timeout→500 retry storm
+  (2026-08-14) and removes slow-Wildbook head-of-line blocking.
+```
+
+- [ ] **Step 5: Normalize line endings, run everything, commit**
+
+```bash
+perl -i -pe 's/\r\n/\n/g' app/main.py docker/docker-compose.prod.yml CHANGELOG.md
+python3 -m pytest tests/ -q
+git add app/main.py docker/docker-compose.prod.yml CHANGELOG.md
+git commit -m "feat: wire fetch lifecycle, body-cap middleware, and per-worker connection limit"
+```
+
+---
+
+## Verification (whole plan)
+
+- [ ] `python3 -m pytest tests/ -q` — entire suite green.
+- [ ] `git diff --ignore-cr-at-eol --stat main...HEAD` — diff matches real changes (no CRLF noise).
+- [ ] Manual smoke (optional, needs models): boot with `python3 -m app.main --device cpu`, POST `/pipeline/` with an unreachable `image_uri` (e.g. `https://10.255.255.1/x.jpg`) → expect 504 within ~70s, not 500, and a WARNING log naming the URI.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures. The fetch state (httpx client + admission semaphore)
+binds to the event loop that first uses it; TestClient creates a fresh loop
+per instance, so state must be reset between tests to avoid cross-loop
+reuse of asyncio primitives."""
+import pytest
+
+from app.utils import image_uri
+
+
+@pytest.fixture(autouse=True)
+def _reset_image_fetch_state():
+    image_uri.reset_fetch_state_for_tests()
+    yield
+    image_uri.reset_fetch_state_for_tests()

--- a/tests/test_body_limit_middleware.py
+++ b/tests/test_body_limit_middleware.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware import BodyLimitMiddleware
+
+
+def _make_app(max_bytes=64):
+    app = FastAPI()
+    app.add_middleware(BodyLimitMiddleware, max_bytes=max_bytes)
+
+    @app.post("/echo")
+    async def echo(payload: dict):
+        return {"n": len(str(payload))}
+    return TestClient(app)
+
+
+def test_small_body_passes():
+    client = _make_app()
+    r = client.post("/echo", json={"a": 1})
+    assert r.status_code == 200
+
+
+def test_oversize_content_length_413():
+    client = _make_app(max_bytes=8)
+    r = client.post("/echo", json={"key": "value-far-over-eight-bytes"})
+    assert r.status_code == 413
+
+
+def test_oversize_chunked_body_413():
+    client = _make_app(max_bytes=8)
+
+    def gen():
+        yield b'{"key": "'
+        yield b"x" * 32
+        yield b'"}'
+    r = client.post("/echo", content=gen(),
+                    headers={"content-type": "application/json"})
+    assert r.status_code == 413
+
+
+def test_non_http_scope_passthrough():
+    # middleware must not touch lifespan scopes: app startup succeeding
+    # under TestClient's context manager proves it
+    with _make_app() as client:
+        assert client.post("/echo", json={"a": 1}).status_code == 200

--- a/tests/test_image_fetch_guards.py
+++ b/tests/test_image_fetch_guards.py
@@ -77,3 +77,9 @@ def test_local_path_reads_regular_file(tmp_path):
     f = tmp_path / "ok.png"
     f.write_bytes(ONE_PX_PNG)
     assert asyncio.run(image_uri.resolve_image_uri(str(f))) == ONE_PX_PNG
+
+
+def test_pil_bomb_guard_is_finite():
+    # process-wide backstop for decode paths that bypass check_image_header
+    assert Image.MAX_IMAGE_PIXELS is not None
+    assert Image.MAX_IMAGE_PIXELS == 150000000

--- a/tests/test_image_fetch_guards.py
+++ b/tests/test_image_fetch_guards.py
@@ -1,0 +1,79 @@
+"""Guards: encoded-length cap for data URIs, stat-first local files,
+header-parsed pixel cap."""
+import asyncio
+import base64
+import io
+import os
+import struct
+import zlib
+
+import pytest
+from PIL import Image
+
+from app.utils import image_uri
+
+# Valid 1x1 red PNG
+ONE_PX_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8"
+    "z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _png_with_dimensions(width, height):
+    """Craft a PNG whose IHDR declares width x height (header-only parse)."""
+    img = Image.new("RGB", (1, 1))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    data = bytearray(buf.getvalue())
+    # IHDR starts at byte 16: 4-byte width, 4-byte height (big-endian)
+    data[16:24] = struct.pack(">II", width, height)
+    # fix the IHDR CRC (bytes 29-33 cover chunk type+data at 12..29)
+    data[29:33] = struct.pack(">I", zlib.crc32(bytes(data[12:29])))
+    return bytes(data)
+
+
+def test_check_image_header_accepts_small_png():
+    image_uri.init_image_fetch()
+    image_uri.check_image_header(ONE_PX_PNG)  # must not raise
+
+
+def test_check_image_header_rejects_bomb():
+    image_uri.init_image_fetch()
+    bomb = _png_with_dimensions(20000, 20000)  # 400 MP > 150 MP cap
+    with pytest.raises(image_uri.ImageTooLargeError):
+        image_uri.check_image_header(bomb)
+
+
+def test_check_image_header_rejects_non_image():
+    image_uri.init_image_fetch()
+    with pytest.raises(ValueError):
+        image_uri.check_image_header(b"\x00\x00\x00\x18ftypmp42 not an image")
+
+
+def test_data_uri_encoded_length_cap(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "8")
+    image_uri.init_image_fetch()
+    big = "data:image/png;base64," + base64.b64encode(b"x" * 64).decode()
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri(big))
+
+
+def test_local_path_rejects_fifo(tmp_path):
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError):
+        asyncio.run(image_uri.resolve_image_uri(str(fifo)))
+
+
+def test_local_path_rejects_oversize(tmp_path, monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "4")
+    f = tmp_path / "big.jpg"
+    f.write_bytes(b"x" * 64)
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri(str(f)))
+
+
+def test_local_path_reads_regular_file(tmp_path):
+    f = tmp_path / "ok.png"
+    f.write_bytes(ONE_PX_PNG)
+    assert asyncio.run(image_uri.resolve_image_uri(str(f))) == ONE_PX_PNG

--- a/tests/test_image_fetch_lifecycle.py
+++ b/tests/test_image_fetch_lifecycle.py
@@ -1,0 +1,46 @@
+"""Lifecycle and settings tests for the shared image-fetch state."""
+import asyncio
+import httpx
+import pytest
+
+from app.utils import image_uri
+
+
+def test_load_fetch_settings_defaults():
+    s = image_uri.load_fetch_settings()
+    assert s["connect_timeout_s"] == 10.0
+    assert s["read_timeout_s"] == 30.0
+    assert s["total_deadline_s"] == 60.0
+    assert s["admission_limit"] == 8
+    assert s["admission_wait_s"] == 20.0
+    assert s["max_image_bytes"] == 52428800
+    assert s["max_pixels"] == 150000000
+
+
+def test_load_fetch_settings_env_override(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_READ_TIMEOUT_S", "5")
+    monkeypatch.setenv("IMAGE_ADMISSION_LIMIT", "2")
+    s = image_uri.load_fetch_settings()
+    assert s["read_timeout_s"] == 5.0
+    assert s["admission_limit"] == 2
+
+
+def test_init_creates_client_and_admission():
+    image_uri.init_image_fetch()
+    assert isinstance(image_uri._client, httpx.AsyncClient)
+    assert isinstance(image_uri._admission, asyncio.Semaphore)
+    # invariant asserted at init: pool max_connections == admission_limit
+    assert image_uri._settings["admission_limit"] == 8
+
+
+def test_init_accepts_mock_transport():
+    transport = httpx.MockTransport(lambda req: httpx.Response(200))
+    image_uri.init_image_fetch(transport=transport)
+    assert image_uri._client is not None
+
+
+def test_reset_clears_state():
+    image_uri.init_image_fetch()
+    image_uri.reset_fetch_state_for_tests()
+    assert image_uri._client is None
+    assert image_uri._admission is None

--- a/tests/test_image_fetch_mapping.py
+++ b/tests/test_image_fetch_mapping.py
@@ -1,0 +1,126 @@
+"""fetch_image_for_request must map every failure class to the spec's
+status code, and admission_slot must 503 on wait timeout."""
+import asyncio
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.utils import image_uri
+from tests.test_image_fetch_guards import ONE_PX_PNG
+
+
+def _status_for(handler):
+    image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(image_uri.fetch_image_for_request("https://wb.example/x.jpg"))
+    return exc.value.status_code
+
+
+def test_success_returns_bytes():
+    image_uri.init_image_fetch(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, content=ONE_PX_PNG)))
+    data = asyncio.run(image_uri.fetch_image_for_request("https://wb.example/ok.png"))
+    assert data == ONE_PX_PNG
+
+
+def test_read_timeout_maps_504():
+    def h(req):
+        raise httpx.ReadTimeout("stall", request=req)
+    assert _status_for(h) == 504
+
+
+def test_connect_error_maps_502():
+    def h(req):
+        raise httpx.ConnectError("refused", request=req)
+    assert _status_for(h) == 502
+
+
+def test_upstream_500_maps_502():
+    assert _status_for(lambda r: httpx.Response(500)) == 502
+
+
+def test_upstream_429_maps_502():
+    assert _status_for(lambda r: httpx.Response(429)) == 502
+
+
+def test_upstream_408_maps_502():
+    assert _status_for(lambda r: httpx.Response(408)) == 502
+
+
+@pytest.mark.parametrize("code", [401, 403, 404, 410, 415])
+def test_upstream_permanent_4xx_maps_400(code):
+    assert _status_for(lambda r, c=code: httpx.Response(c)) == 400
+
+
+def test_too_many_redirects_maps_400():
+    def h(req):
+        return httpx.Response(302, headers={"location": str(req.url)})
+    assert _status_for(h) == 400
+
+
+def test_decoding_error_maps_502():
+    def h(req):
+        raise httpx.DecodingError("bad encoding", request=req)
+    assert _status_for(h) == 502
+
+
+def test_unparseable_image_maps_400():
+    assert _status_for(lambda r: httpx.Response(200, content=b"mp4junk" * 4)) == 400
+
+
+def test_invalid_data_uri_maps_400():
+    image_uri.init_image_fetch()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(image_uri.fetch_image_for_request("data:image/png;base64"))
+    assert exc.value.status_code == 400
+
+
+def test_total_deadline_maps_504(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "0.05")
+
+    async def run():
+        async def drip():
+            yield b"a"
+            await asyncio.sleep(0.2)
+            yield b"b"
+        image_uri.init_image_fetch(
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, content=drip())))
+        with pytest.raises(HTTPException) as exc:
+            await image_uri.fetch_image_for_request("https://wb.example/drip.jpg")
+        assert exc.value.status_code == 504
+    asyncio.run(run())
+
+
+def test_admission_slot_503_on_wait_timeout(monkeypatch):
+    monkeypatch.setenv("IMAGE_ADMISSION_LIMIT", "1")
+    monkeypatch.setenv("IMAGE_ADMISSION_WAIT_S", "0.05")
+
+    async def run():
+        image_uri.init_image_fetch()
+        async with image_uri.admission_slot():
+            with pytest.raises(HTTPException) as exc:
+                async with image_uri.admission_slot():
+                    pass
+            assert exc.value.status_code == 503
+    asyncio.run(run())
+
+
+def test_admission_slot_releases_on_exception():
+    async def run():
+        image_uri.init_image_fetch()
+        with pytest.raises(RuntimeError):
+            async with image_uri.admission_slot():
+                raise RuntimeError("boom")
+        # slot must be free again
+        async with image_uri.admission_slot():
+            pass
+    asyncio.run(run())
+
+
+def test_failure_log_contains_sanitized_uri(caplog):
+    def h(req):
+        raise httpx.ConnectError("refused", request=req)
+    image_uri.init_image_fetch(transport=httpx.MockTransport(h))
+    with pytest.raises(HTTPException):
+        asyncio.run(image_uri.fetch_image_for_request("https://wb.example/y.jpg"))
+    assert any("https://wb.example/y.jpg" in r.message for r in caplog.records)

--- a/tests/test_image_fetch_url.py
+++ b/tests/test_image_fetch_url.py
@@ -28,8 +28,13 @@ def test_url_fetch_declared_oversize_rejected_before_body():
 
 def test_url_fetch_undeclared_oversize_rejected_midstream(monkeypatch):
     monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "10")
-    _init_with(lambda req: httpx.Response(200, content=b"x" * 32))
-    with pytest.raises(image_uri.ImageTooLargeError):
+    async def no_length_body():
+        # Generator body so httpx doesn't auto-set content-length
+        yield b"x" * 20
+    def handler(req):
+        return httpx.Response(200, content=no_length_body())
+    _init_with(handler)
+    with pytest.raises(image_uri.ImageTooLargeError, match="mid-stream"):
         asyncio.run(image_uri.resolve_image_uri("https://wb.example/liar.jpg"))
 
 

--- a/tests/test_image_fetch_url.py
+++ b/tests/test_image_fetch_url.py
@@ -1,0 +1,80 @@
+"""URL-branch tests for resolve_image_uri using httpx.MockTransport.
+
+MockTransport cannot simulate timeouts by sleeping; handlers raise
+httpx.ReadTimeout directly (per httpx docs)."""
+import asyncio
+import httpx
+import pytest
+
+from app.utils import image_uri
+
+
+def _init_with(handler):
+    image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+
+
+def test_url_fetch_returns_bytes():
+    _init_with(lambda req: httpx.Response(200, content=b"jpegbytes"))
+    result = asyncio.run(image_uri.resolve_image_uri("https://wb.example/img.jpg"))
+    assert result == b"jpegbytes"
+
+
+def test_url_fetch_declared_oversize_rejected_before_body():
+    _init_with(lambda req: httpx.Response(
+        200, headers={"content-length": str(60 * 1024 * 1024)}, content=b""))
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/big.jpg"))
+
+
+def test_url_fetch_undeclared_oversize_rejected_midstream(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_MAX_BYTES", "10")
+    _init_with(lambda req: httpx.Response(200, content=b"x" * 32))
+    with pytest.raises(image_uri.ImageTooLargeError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/liar.jpg"))
+
+
+def test_url_fetch_empty_body_rejected():
+    _init_with(lambda req: httpx.Response(200, content=b""))
+    with pytest.raises(image_uri.EmptyImageError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/empty.jpg"))
+
+
+def test_url_fetch_read_timeout_propagates():
+    def handler(req):
+        raise httpx.ReadTimeout("stalled", request=req)
+    _init_with(handler)
+    with pytest.raises(httpx.ReadTimeout):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/slow.jpg"))
+
+
+def test_url_fetch_total_deadline(monkeypatch):
+    monkeypatch.setenv("IMAGE_FETCH_TOTAL_DEADLINE_S", "0.05")
+
+    async def run():
+        async def slow_drip():
+            # slower than the deadline but each read under the read timeout
+            yield b"a"
+            await asyncio.sleep(0.2)
+            yield b"b"
+        def handler(req):
+            return httpx.Response(200, content=slow_drip())
+        image_uri.init_image_fetch(transport=httpx.MockTransport(handler))
+        with pytest.raises(asyncio.TimeoutError):
+            await image_uri.resolve_image_uri("https://wb.example/drip.jpg")
+    asyncio.run(run())
+
+
+def test_url_fetch_upstream_error_raises_status_error():
+    _init_with(lambda req: httpx.Response(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(image_uri.resolve_image_uri("https://wb.example/oops.jpg"))
+
+
+def test_url_fetch_follows_redirect():
+    def handler(req):
+        if req.url.path == "/a":
+            return httpx.Response(302, headers={"location": "https://cdn.example/b"})
+        return httpx.Response(200, content=b"moved")
+    _init_with(handler)
+    result = asyncio.run(image_uri.resolve_image_uri("https://wb.example/a"))
+    assert result == b"moved"

--- a/tests/test_pipeline_router_classifier.py
+++ b/tests/test_pipeline_router_classifier.py
@@ -5,6 +5,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from app.routers import pipeline_router
 
+VALID_PNG_DATA_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
 
 def _make_app_with_models(predict_model, classify_model, extract_model):
     """Build a minimal FastAPI app with monkey-patched ModelHandler."""
@@ -63,7 +68,7 @@ def test_pipeline_classify_densenet_classifier_emits_top_level_iaclass_and_viewp
         "predict_model_id": "p",
         "classify_model_id": "c",
         "extract_model_id": "e",
-        "image_uri": "data:image/png;base64,iVBORw0KGgo=",
+        "image_uri": VALID_PNG_DATA_URI,
     })
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -102,7 +107,7 @@ def test_pipeline_classify_densenet_classifier_pure_viewpoint_omits_iaclass():
     resp = client.post("/pipeline/", json={
         "predict_model_id": "p", "classify_model_id": "c",
         "extract_model_id": "e",
-        "image_uri": "data:image/png;base64,iVBORw0KGgo=",
+        "image_uri": VALID_PNG_DATA_URI,
     })
     body = resp.json()
     r = body["results"][0]
@@ -151,7 +156,7 @@ def test_pipeline_classify_efficientnet_compound_labels_emits_top_level_iaclass_
     resp = client.post("/pipeline/", json={
         "predict_model_id": "p", "classify_model_id": "c",
         "extract_model_id": "e",
-        "image_uri": "data:image/png;base64,iVBORw0KGgo=",
+        "image_uri": VALID_PNG_DATA_URI,
     })
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -173,6 +178,6 @@ def test_pipeline_classify_densenet_orientation_rejected_with_400():
     client = _make_app_with_models(pm, cm, em)
     resp = client.post("/pipeline/", json={
         "predict_model_id": "p", "classify_model_id": "c",
-        "extract_model_id": "e", "image_uri": "data:image/png;base64,iVBORw0KGgo=",
+        "extract_model_id": "e", "image_uri": VALID_PNG_DATA_URI,
     })
     assert resp.status_code == 400

--- a/tests/test_pipeline_router_sentinel_species.py
+++ b/tests/test_pipeline_router_sentinel_species.py
@@ -16,6 +16,11 @@ from fastapi.testclient import TestClient
 
 from app.routers import pipeline_router
 
+VALID_PNG_DATA_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
 
 def _client(classify_predictions):
     from app.models.efficientnet import EfficientNetModel
@@ -56,7 +61,7 @@ def _client(classify_predictions):
 
 def _post(client):
     return client.post("/pipeline/", json={
-        "image_uri": "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+        "image_uri": VALID_PNG_DATA_URI,
         "predict_model_id": "p",
         "classify_model_id": "c",
         "extract_model_id": "e",

--- a/tests/test_pipeline_router_theta.py
+++ b/tests/test_pipeline_router_theta.py
@@ -20,6 +20,11 @@ from fastapi.testclient import TestClient
 
 from app.routers import pipeline_router
 
+VALID_PNG_DATA_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
 
 def _client(predict_model, classify_model, extract_model, orientation_model=None):
     app = FastAPI()
@@ -70,7 +75,7 @@ def _orientation(thetas, effective_bboxes=None):
     return om
 
 
-PAYLOAD = {"image_uri": "data:image/png;base64,iVBORw0KGgo=",
+PAYLOAD = {"image_uri": VALID_PNG_DATA_URI,
            "predict_model_id": "p", "classify_model_id": "c",
            "extract_model_id": "e"}
 

--- a/tests/test_router_fetch_isolation.py
+++ b/tests/test_router_fetch_isolation.py
@@ -1,0 +1,59 @@
+# tests/test_router_fetch_isolation.py
+"""A request that fails at fetch must never touch the inference semaphore,
+and mapped statuses must pass through the router unchanged."""
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.routers import pipeline_router
+from app.utils import image_uri
+
+
+class SpySemaphore:
+    def __init__(self):
+        self.acquired = False
+
+    async def __aenter__(self):
+        self.acquired = True
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _client(monkeypatch, spy):
+    monkeypatch.setattr(pipeline_router, "pipeline_semaphore", spy)
+    app = FastAPI()
+    app.include_router(pipeline_router.router)
+    handler = MagicMock()
+    handler.get_model.return_value = MagicMock()
+    handler.get_model_info.return_value = {"config": {}}
+    handler.list_models.return_value = {}
+    app.state.model_handler = handler
+    return TestClient(app)
+
+
+PAYLOAD = {
+    "predict_model_id": "p", "classify_model_id": "c",
+    "extract_model_id": "e", "image_uri": "https://wb.example/img.jpg",
+}
+
+
+@pytest.mark.parametrize("code", [400, 502, 503, 504])
+def test_fetch_failure_status_passes_through_and_skips_inference(
+        monkeypatch, code):
+    spy = SpySemaphore()
+
+    async def failing_fetch(uri):
+        raise HTTPException(status_code=code, detail="mapped upstream failure")
+    monkeypatch.setattr(pipeline_router, "fetch_image_for_request", failing_fetch)
+    # model-type validation must pass so we reach the fetch
+    monkeypatch.setattr(pipeline_router, "isinstance",
+                        lambda obj, cls: True, raising=False)
+
+    client = _client(monkeypatch, spy)
+    r = client.post("/pipeline/", json=PAYLOAD)
+    assert r.status_code == code
+    assert spy.acquired is False


### PR DESCRIPTION
## Why

Production incident 2026-08-14: GiraffeSpotter stalled serving media. ml-service's image fetch used httpx's unconfigured 5s default read timeout; the `ReadTimeout` escaped as a 500; Wildbook's queue re-dispatched the job every ~6s (retry storm); and because the fetch ran inside the 2-slot inference semaphore, each stalled fetch also throttled every other installation sharing the service.

## What

Design doc (Codex-reviewed, 4 adversarial rounds to convergence): `docs/plans/2026-08-14-image-fetch-resilience-design.md`

- **Shared, lifespan-owned httpx client** — connect 10s / read 30s / 60s total wall-clock deadline (`asyncio.wait_for`; httpx's read timeout is per-read inactivity and never fires on a slow-drip peer), `follow_redirects` with `max_redirects=3` and per-hop logging.
- **Streaming fetch with enforced caps** — 50MB streamed size cap (declared Content-Length pre-check + authoritative mid-stream count), 150MP decoded-pixel cap checked from the image header before any decode, finite process-wide `Image.MAX_IMAGE_PIXELS` backstop for decode paths outside the helper.
- **Admission decoupled from inference** — per-worker admission semaphore (8, bounded 20s wait → 503) held from fetch start through inference end; the inference semaphores now wrap only model work in all four routers (pipeline/predict/classify/extract). A stalled upstream holds admission slots, never GPU slots. Regression-tested: a request failing at fetch never touches the inference semaphore.
- **Retry-ladder-correct status mapping** — timeout → 504, transport/upstream-5xx/408/429 → 502 (Wildbook retries with back-off), permanent upstream 4xx / oversized / undecodable / malformed → 400 (job dropped instead of storming). Every failure logs the sanitized `image_uri` — the incident was anonymous without it.
- **Pre-handler body bound** — pure-ASGI body-cap middleware (4MB default → 413) plus uvicorn `--limit-concurrency 32`; all knobs env-tunable and documented in the prod compose file.

## Testing

- 271 tests green (48 new across 5 test files), TDD per task.
- Note: dev suite ran on Python 3.12 / httpx 0.28; prod pins 3.10 / 0.26. The 0.26 exception hierarchy and client API were manually verified identical, but run the suite once in the prod container before deploying.

## Follow-ups (not in this PR)

- `explain_router` still uses a throwaway 5s-default client; `wbia_compat_router` calls synchronous `httpx.get` on the event loop — both should route through `fetch_image_for_request` + `admission_slot`.
- Wildbook side: GiraffeSpotter's ~6s hot retry loop suggests a build predating the current `MlServiceClient` failure ladder; upgrading converts storms into back-off retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)