### PR TITLE
fix(config): make the image-fetch and explain env knobs actually reachable

### DIFF
--- a/docker/_env
+++ b/docker/_env
@@ -26,7 +26,7 @@ MODEL_CONFIG=/data0/user/model_config.json
 # PyTorch device: cuda, cpu (default: cuda)
 # DEVICE=cuda
 
-# Number of uvicorn workers (default: 1 — use 1 for GPU to avoid VRAM contention)
+# Number of uvicorn workers (default: 4 — set 1 for GPU to avoid VRAM contention)
 # WORKERS=1
 
 # Host port to expose (default: 6050)
@@ -34,3 +34,54 @@ MODEL_CONFIG=/data0/user/model_config.json
 
 # Directory shared with WBIA/Wildbook for image paths (so image_uuid_list file paths resolve)
 # DATA_DB_DIR=/data/db
+
+# Image fetch and admission ------------------------------------------------
+#
+# The service fetches every image_uri itself, so these bound what one slow or
+# hostile upstream can cost. All have in-code defaults; leaving them unset
+# here keeps current behaviour. Changing any of them requires a restart.
+
+# Seconds to wait for a connection to an image host to be established
+# (default: 10). Raise where the path to upstreams is lossy or slow: a
+# connection that times out here costs a full retry, not a slow success.
+# IMAGE_FETCH_CONNECT_TIMEOUT_S=10
+
+# Seconds of silence permitted between reads, NOT total transfer time
+# (default: 30). A slow but steady download will not trip this.
+# IMAGE_FETCH_READ_TIMEOUT_S=30
+
+# Hard ceiling on one fetch, start to finish (default: 60). This is what
+# stops a slow transfer holding an admission slot indefinitely -- and what
+# cuts off large images on a degraded link. Raise where upstreams are slow.
+# IMAGE_FETCH_TOTAL_DEADLINE_S=60
+
+# Maximum image size accepted, in bytes (default: 52428800 = 50MB).
+# IMAGE_FETCH_MAX_BYTES=52428800
+
+# Concurrent image fetches PER WORKER (default: 8). Effective total is this
+# times WORKERS, so 4 workers means 32 concurrent fetches against upstreams.
+# IMAGE_ADMISSION_LIMIT=8
+
+# Seconds a request waits for an admission slot before 503 (default: 20).
+# IMAGE_ADMISSION_WAIT_S=20
+
+# Decoded-pixel ceiling, a decompression-bomb guard (default: 150000000).
+# IMAGE_MAX_PIXELS=150000000
+
+# Maximum request body accepted, in bytes (default: 4194304 = 4MB).
+# Installs POSTing data URIs need ~4/3x the image size for base64 inflation:
+# a 50MB image needs roughly a 67MB cap.
+# MAX_REQUEST_BODY_BYTES=4194304
+
+# cv2's own decode backstop, read by OpenCV rather than by app code. Not
+# passed through by default -- uncomment the matching line in
+# docker-compose.prod.yml to enable it.
+# OPENCV_IO_MAX_IMAGE_PIXELS=1073741824
+
+# Endpoint defaults --------------------------------------------------------
+
+# Model used by /explain/ (PairX) when the caller omits model_id
+# (default: miewid-msv4.1). Must name a MiewID model THIS instance loads --
+# registries differ between instances, and an id that is not loaded returns
+# 404. Set it where your registry uses a different name, e.g.:
+# EXPLAIN_DEFAULT_MODEL_ID=miewid-msv4_v3

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -17,12 +17,23 @@ services:
       - ultralytics_config:/root/.config/Ultralytics
     environment:
       - PYTHONPATH=/app
-    # Image-fetch resilience knobs (defaults in code; override via environment:)
-    #   IMAGE_FETCH_CONNECT_TIMEOUT_S=10  IMAGE_FETCH_READ_TIMEOUT_S=30
-    #   IMAGE_FETCH_TOTAL_DEADLINE_S=60   IMAGE_ADMISSION_LIMIT=8
-    #   IMAGE_ADMISSION_WAIT_S=20         IMAGE_FETCH_MAX_BYTES=52428800
-    #   IMAGE_MAX_PIXELS=150000000        MAX_REQUEST_BODY_BYTES=4194304
-    #   OPENCV_IO_MAX_IMAGE_PIXELS  (cv2 decode backstop; cv2 default ~1GP)
+      # Image-fetch resilience. Each falls back to the in-code default when
+      # the variable is unset in .env, so leaving .env untouched preserves
+      # current behaviour.
+      - IMAGE_FETCH_CONNECT_TIMEOUT_S=${IMAGE_FETCH_CONNECT_TIMEOUT_S:-10}
+      - IMAGE_FETCH_READ_TIMEOUT_S=${IMAGE_FETCH_READ_TIMEOUT_S:-30}
+      - IMAGE_FETCH_TOTAL_DEADLINE_S=${IMAGE_FETCH_TOTAL_DEADLINE_S:-60}
+      - IMAGE_FETCH_MAX_BYTES=${IMAGE_FETCH_MAX_BYTES:-52428800}
+      - IMAGE_ADMISSION_LIMIT=${IMAGE_ADMISSION_LIMIT:-8}
+      - IMAGE_ADMISSION_WAIT_S=${IMAGE_ADMISSION_WAIT_S:-20}
+      - IMAGE_MAX_PIXELS=${IMAGE_MAX_PIXELS:-150000000}
+      - MAX_REQUEST_BODY_BYTES=${MAX_REQUEST_BODY_BYTES:-4194304}
+      # PairX fallback when a caller omits model_id. Must name a MiewID
+      # model this instance loads -- registries differ between instances.
+      - EXPLAIN_DEFAULT_MODEL_ID=${EXPLAIN_DEFAULT_MODEL_ID:-miewid-msv4.1}
+      # cv2 decode backstop, read by OpenCV itself rather than app code.
+      # Uncomment to override cv2's ~1GP default:
+      # - OPENCV_IO_MAX_IMAGE_PIXELS=${OPENCV_IO_MAX_IMAGE_PIXELS:-1073741824}
     # Data-URI installs: MAX_REQUEST_BODY_BYTES must cover base64 inflation
     #   (~4/3x: a 50MB image needs ~67MB body cap).
     # Raise MAX_REQUEST_BODY_BYTES only for installations POSTing data URIs.


### PR DESCRIPTION
## Problem

`app/` reads **nine** environment variables via `os.getenv`, and **none of them could be set by a deployment**.

`docker-compose.prod.yml`'s `environment:` block contained only:

```yaml
    environment:
      - PYTHONPATH=/app
```

Docker Compose uses `.env` for interpolation **inside the compose file**, not for injecting variables into the container. So an operator setting `IMAGE_FETCH_TOTAL_DEADLINE_S=180` in `.env` would see the service ignore it — no effect, no warning, nothing to explain why.

- **#39** shipped eight of these as image-fetch resilience knobs and added only *comments* to the compose file.
- **#40** added the ninth (`EXPLAIN_DEFAULT_MODEL_ID`) with the same omission.
- `docker/_env`, the `.env` template, documented none of the nine.

## Changes

**1. Compose passes all nine through**, each with its in-code default:

```yaml
      - IMAGE_FETCH_CONNECT_TIMEOUT_S=${IMAGE_FETCH_CONNECT_TIMEOUT_S:-10}
      - IMAGE_FETCH_READ_TIMEOUT_S=${IMAGE_FETCH_READ_TIMEOUT_S:-30}
      - IMAGE_FETCH_TOTAL_DEADLINE_S=${IMAGE_FETCH_TOTAL_DEADLINE_S:-60}
      - IMAGE_FETCH_MAX_BYTES=${IMAGE_FETCH_MAX_BYTES:-52428800}
      - IMAGE_ADMISSION_LIMIT=${IMAGE_ADMISSION_LIMIT:-8}
      - IMAGE_ADMISSION_WAIT_S=${IMAGE_ADMISSION_WAIT_S:-20}
      - IMAGE_MAX_PIXELS=${IMAGE_MAX_PIXELS:-150000000}
      - MAX_REQUEST_BODY_BYTES=${MAX_REQUEST_BODY_BYTES:-4194304}
      - EXPLAIN_DEFAULT_MODEL_ID=${EXPLAIN_DEFAULT_MODEL_ID:-miewid-msv4.1}
```

Every fallback is byte-identical to the value in `app/`, verified by cross-checking the compose file against `os.getenv` call sites — **0 mismatches**. A deployment whose `.env` lacks these is completely unaffected.

**2. `:-` rather than `-`, deliberately.** An operator writing `IMAGE_FETCH_READ_TIMEOUT_S=` with no value would otherwise inject an empty string, and `float("")` raises `ValueError` at startup. `:-` treats unset and empty alike.

**3. `docker/_env` documents all nine**, commented out, with the reasoning an operator actually needs — notably that `IMAGE_FETCH_READ_TIMEOUT_S` is *per-read inactivity*, not a transfer-wide bound (that's `IMAGE_FETCH_TOTAL_DEADLINE_S`), and that `IMAGE_ADMISSION_LIMIT` is **per worker**, so effective concurrency is `IMAGE_ADMISSION_LIMIT × WORKERS`.

**4. `OPENCV_IO_MAX_IMAGE_PIXELS` left commented in both files.** OpenCV reads it directly rather than app code, and wiring a guessed override would change decoder behaviour.

**5. Corrected a doc/reality contradiction:** `_env` claimed `WORKERS` defaults to 1; the compose file uses `${WORKERS:-4}`.

## Verification

```
$ docker compose config                 # every default resolves
$ IMAGE_FETCH_TOTAL_DEADLINE_S=180 \
  EXPLAIN_DEFAULT_MODEL_ID=miewid-msv4_v3 docker compose config
      EXPLAIN_DEFAULT_MODEL_ID: miewid-msv4_v3
      IMAGE_FETCH_TOTAL_DEADLINE_S: "180"
$ IMAGE_FETCH_READ_TIMEOUT_S= docker compose config
      IMAGE_FETCH_READ_TIMEOUT_S: "30"     # empty falls back, not ""
```

Automated cross-check: every `os.getenv` variable is wired in compose and documented in `_env`, with no orphans in either direction. 286 tests pass.

Reviewed by codex: no Critical or Major findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)