### PR TITLE
fix(explain): image-fetch resilience + PairX off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+- `/explain/` (PairX) joins the image-fetch resilience path. It was the one
+  router PR #39 did not migrate and still used an inline `httpx.AsyncClient()`
+  -- httpx's 5s default timeout, no env knob -- inside a bare
+  `except Exception` that reported read timeouts, upstream 5xx and undecodable
+  bodies alike as 400, which Wildbook does not retry. It now uses
+  `fetch_image_for_request` behind `admission_slot` (one slot per image, since
+  a pair request fans out to 2N fetches), so the `IMAGE_FETCH_*` knobs apply
+  and statuses map correctly (504 slow upstream, 502 upstream fault, 400
+  caller error). `process_asyncio_result` no longer flattens those back to 400.
+  Local paths are resolved by the shared helper, which does not expand a
+  leading `~`; absolute paths, relative paths, URLs and (newly) data URIs are
+  unaffected.
+- `/explain/` validates the pairing, the batch size and every bbox/theta
+  *before* fetching any image, so a request already known to be invalid takes
+  no slots from the process-wide admission gate that the other routers queue
+  on. Non-finite bbox values and thetas are now rejected explicitly: a bare
+  `NaN` survives `json.loads` and every `x < 0` test, then broke `int()` deep
+  in cropping.
 - Image-fetch resilience (design: docs/plans/2026-08-14-image-fetch-resilience-design.md):
   image downloads now use a shared client with explicit timeouts and a 60s total
   deadline, run outside the inference semaphores behind a bounded admission gate,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
   on. Non-finite bbox values and thetas are now rejected explicitly: a bare
   `NaN` survives `json.loads` and every `x < 0` test, then broke `int()` deep
   in cropping.
+- PairX inference moved off the event loop (`run_in_threadpool`). Running the
+  synchronous torch forward+backward inline pinned the loop for its whole
+  duration and starved every concurrent image fetch on that worker -- the
+  Flukebook incident of 2026-08-28, where a sibling `/extract/` fetch blew its
+  60s deadline on an asset that had served 200 in under a second. Because that
+  offload makes two explains genuinely parallel against one shared model,
+  `MAX_CONCURRENT_EXPLANATIONS` drops 2 -> 1 to keep PAIR-X's backward pass and
+  `zero_grad()` from racing; inline execution already serialized them, so
+  observed concurrency is unchanged.
+
 - Image-fetch resilience (design: docs/plans/2026-08-14-image-fetch-resilience-design.md):
   image downloads now use a shared client with explicit timeouts and a 60s total
   deadline, run outside the inference semaphores behind a bounded admission gate,

--- a/app/routers/explain_router.py
+++ b/app/routers/explain_router.py
@@ -12,6 +12,7 @@ import torchvision.transforms as transforms
 from albumentations.pytorch import ToTensorV2
 from PIL import Image
 from fastapi import APIRouter, HTTPException, Request, Depends
+from fastapi.concurrency import run_in_threadpool
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -31,7 +32,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/explain", tags=["Explain"])
 
 MAX_BATCH_SIZE = 16
-MAX_CONCURRENT_EXPLANATIONS = 2
+# 1, not 2. PairX now runs in a worker thread, so a semaphore of 2 would make
+# two explains genuinely concurrent against a single shared model instance --
+# and PAIR-X backpropagates, so they would race on .grad and on the
+# zero_grad(set_to_none=True) in run_pairx's finally. While run_pairx ran
+# inline on the event loop the second holder could never be scheduled, so 2
+# was already 1 in practice; this makes that explicit rather than newly
+# serial. Matches the phase-0 finding that serializing CUDA work beat
+# overlapping it on every axis (throughput, p95, p99).
+MAX_CONCURRENT_EXPLANATIONS = 1
 explain_semaphore = asyncio.Semaphore(MAX_CONCURRENT_EXPLANATIONS)
 
 async def get_model_handler(request: Request) -> ModelHandler:
@@ -436,7 +445,16 @@ async def read_items(
     async with explain_semaphore:
         if body.algorithm.lower() == "pairx":
             model = model_entry.model
-            visualizations = run_pairx(image1s_transformed, image2s_transformed, image1s, image2s, model, body.layer_key, body.k_lines, body.k_colors, body.visualization_type)
+            # PairX is a synchronous torch forward+backward. Run inline it
+            # pinned the event loop for its whole duration, so every image
+            # fetch in flight on this worker was starved until it returned --
+            # the 2026-08-28 Flukebook incident, where a sibling /extract/
+            # fetch blew its 60s deadline on an asset that had served 200 in
+            # under a second, and the next /explain/ 400'd on its own timeout.
+            visualizations = await run_in_threadpool(
+                run_pairx, image1s_transformed, image2s_transformed,
+                image1s, image2s, model, body.layer_key,
+                body.k_lines, body.k_colors, body.visualization_type)
         else:
             raise HTTPException(status_code=400, detail="Unsupported algorithm.")
     

--- a/app/routers/explain_router.py
+++ b/app/routers/explain_router.py
@@ -1,12 +1,11 @@
 import asyncio
 import base64
 import logging
+import math
 import os
-from pathlib import Path
 
 import albumentations
 import cv2
-import httpx
 import numpy as np
 import torch
 import torchvision.transforms as transforms
@@ -21,6 +20,11 @@ from pairx import explain
 from app.models.miewid import MiewidModel
 from app.models.model_handler import ModelHandler
 from app.utils.helpers import get_chip_from_img
+from app.utils.image_uri import (
+    admission_slot,
+    fetch_image_for_request,
+    sanitize_uri_for_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,10 +33,6 @@ router = APIRouter(prefix="/explain", tags=["Explain"])
 MAX_BATCH_SIZE = 16
 MAX_CONCURRENT_EXPLANATIONS = 2
 explain_semaphore = asyncio.Semaphore(MAX_CONCURRENT_EXPLANATIONS)
-
-def is_url(string):
-    """Checks if a string is formatted as a url"""
-    return string.startswith(('http://', 'https://'))
 
 async def get_model_handler(request: Request) -> ModelHandler:
     """Dependency to get the model handler from the app state."""
@@ -82,8 +82,17 @@ def validate_img_parameters(bbox, theta):
     if len(bbox) != 4:
         raise HTTPException(status_code=400, detail=f"Each bounding box should have 4 values")
     for x in bbox:
+        # NaN must be rejected explicitly: json.loads accepts a bare NaN,
+        # Pydantic keeps it as a float, and every `x < 0` comparison against
+        # it is False -- so it reaches int() in get_chip_from_img and raises.
+        # That is a permanent caller error, and as a 500 Wildbook would retry
+        # it forever.
+        if not math.isfinite(x):
+            raise HTTPException(status_code=400, detail="Bounding box values must be finite")
         if x < 0:
             raise HTTPException(status_code=400, detail="Bounding box values should be positive")
+    if not math.isfinite(theta):
+        raise HTTPException(status_code=400, detail="Theta must be finite")
 
 def validate_vis_parameters(body):
     """Checks if body parameters related to a specific visualization algorithm are valid."""
@@ -168,22 +177,35 @@ async def process_image(uri, bbox, theta, crop_bbox, model, device):
     If crop_bbox is true, the preptransform image will be cropped. The transformed image will always be cropped.
     The transformed image will be stored on the device provided, ("cpu", "cuda", etc.)"""
     uri = uri.strip()
-    try:
-        if is_url(uri):
-            async with httpx.AsyncClient() as client:
-                response = await client.get(uri)
-            if response.status_code != 200:
-                raise HTTPException(status_code=400, detail=f"Failed to download image: {response.status_code}")
-            image_bytes = np.frombuffer(response.content, np.uint8)
-            image = cv2.imdecode(image_bytes, cv2.IMREAD_COLOR)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        else:
-            path = str(Path(uri).expanduser().resolve())
-            image = cv2.imread(path)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Error loading image: {str(e)}")
+    # The shared fetch path (URL, data URI, or local path) with explicit
+    # timeouts, a byte/pixel cap, and retry-ladder-correct statuses: 504 for a
+    # slow upstream, 502 for an upstream fault, 400 only for a genuine caller
+    # error. The inline httpx.AsyncClient() this replaces used httpx's 5s
+    # default and a bare `except Exception` that reported every one of those as
+    # 400 -- which Wildbook does not retry.
+    #
+    # One admission slot per image, not per request: /explain fans out to 2N
+    # images through asyncio.gather, and the shared client is built with
+    # pool=None on the explicit promise that the admission semaphore is what
+    # holds concurrent requests down to max_connections.
+    async with admission_slot():
+        image_bytes = await fetch_image_for_request(uri)
 
+    image = cv2.imdecode(np.frombuffer(image_bytes, np.uint8), cv2.IMREAD_COLOR)
+    if image is None:
+        # check_image_header() already accepted the header, so this is a body
+        # PIL can parse and OpenCV cannot. Guard it: cv2.cvtColor(None, ...)
+        # raises '(-215:Assertion failed) !_src.empty()', which used to reach
+        # the caller as the entire error detail.
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not decode image: {sanitize_uri_for_response(uri)}")
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+    # Retained deliberately. read_items() validates every bbox/theta before it
+    # fetches anything, so this is redundant on that path -- but it keeps
+    # process_image() correct on its own terms rather than relying on its one
+    # caller having checked first.
     validate_img_parameters(bbox, theta)
 
     # extend_bb_list pads missing bboxes with [0, 0, 0, 0]. When the
@@ -214,12 +236,25 @@ async def process_image(uri, bbox, theta, crop_bbox, model, device):
     return image, transformed_image.to(device)
 
 def process_asyncio_result(result):
-    """Processes a result of process_image() when it is run via asyncio."""
+    """Processes a result of process_image() when it is run via asyncio.
+
+    An HTTPException passes through untouched. process_image has already
+    mapped the failure to the right status, and re-wrapping it as 400 here
+    undid that for every image: a 504 from a stalled Wildbook reached the
+    caller as a permanent client error it would never retry.
+
+    Anything else escaping process_image is a fault in this service, not in
+    the request, so it is a 500 -- and its message stays in the log rather
+    than in the response body.
+    """
+    if isinstance(result, HTTPException):
+        raise result
     if isinstance(result, Exception):
-        raise HTTPException(status_code=400, detail=f"{str(result)}")
-    else:
-        image, transform = result
-        return image, transform
+        logger.error("Unhandled error preparing an explain image",
+                     exc_info=result)
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+    image, transform = result
+    return image, transform
 
 def run_pairx(imgs1_transformed, imgs2_transformed, imgs1, imgs2, model, layer_key, 
         k_lines, k_colors, visualization_type):
@@ -348,6 +383,25 @@ async def read_items(
     theta1s = extend_theta_list(body.image1_uris, body.theta1)
     theta2s = extend_theta_list(body.image2_uris, body.theta2)
 
+    # Check the pairing and the crop parameters BEFORE fetching anything.
+    # These are permanent caller errors, and every image fetched takes a slot
+    # from the process-wide admission gate that /extract, /predict, /classify
+    # and /pipeline are also queueing on -- so a request already known to be
+    # invalid must not consume any. Same reasoning as resolving the model
+    # first, one step up.
+    if len(body.image1_uris) != 1:
+        if len(body.image1_uris) != len(body.image2_uris):
+            raise HTTPException(status_code=400, detail="Either provide only one image 1 or the same number of image1s and image2s.")
+        if len(body.image1_uris) > MAX_BATCH_SIZE:
+            raise HTTPException(status_code=400, detail=f"Batch exceeded max size of {str(MAX_BATCH_SIZE)}")
+    # Zip against the URI lists so validation covers exactly the images the
+    # fetch loops below will process -- no more (a caller's unused surplus
+    # bbox should not fail the request) and no fewer.
+    for _, bb, theta in zip(body.image1_uris, bb1s, theta1s):
+        validate_img_parameters(bb, theta)
+    for _, bb, theta in zip(body.image2_uris, bb2s, theta2s):
+        validate_img_parameters(bb, theta)
+
     # Read in images asynchronously
     tasks = []
     for uri, bb, theta in zip(body.image1_uris, bb1s, theta1s):
@@ -369,18 +423,14 @@ async def read_items(
             image2s.append(image2)
             image2s_transformed.append(image2_transformed)
     else:
-        if len(body.image1_uris) != len(body.image2_uris):
-            raise HTTPException(status_code=400, detail="Either provide only one image 1 or the same number of image1s and image2s.")
-        else:
-            if len(body.image1_uris) > MAX_BATCH_SIZE:
-                raise HTTPException(status_code=400, detail=f"Batch exceeded max size of {str(MAX_BATCH_SIZE)}")
-            for i in range(len(body.image1_uris)):
-                image1, image1_transformed = process_asyncio_result(results1[i])
-                image1s.append(image1)
-                image1s_transformed.append(image1_transformed)
-                image2, image2_transformed = process_asyncio_result(results2[i])
-                image2s.append(image2)
-                image2s_transformed.append(image2_transformed)
+        # Pairing and batch size were validated before the fetch above.
+        for i in range(len(body.image1_uris)):
+            image1, image1_transformed = process_asyncio_result(results1[i])
+            image1s.append(image1)
+            image1s_transformed.append(image1_transformed)
+            image2, image2_transformed = process_asyncio_result(results2[i])
+            image2s.append(image2)
+            image2s_transformed.append(image2_transformed)
 
     # Only apply semaphore to the actual prediction
     async with explain_semaphore:

--- a/tests/test_explain_router_fetch.py
+++ b/tests/test_explain_router_fetch.py
@@ -1,0 +1,202 @@
+"""/explain/ must use the shared hardened image-fetch path.
+
+Regression tests for the Flukebook incident of 2026-08-28. explain_router
+was the only router PR #39 did not migrate: it kept an inline
+`httpx.AsyncClient()` (httpx's 5s default timeout, no env knob) wrapped in a
+bare `except Exception` that mapped *every* failure -- read timeout, upstream
+5xx, undecodable body -- to 400. Wildbook does not retry 4xx, so a transient
+upstream stall was reported to the caller as a permanent client error.
+
+The observed signature was `POST /explain/ 400` seconds after a sibling
+`POST /extract/ 504 ... 60001 ms` on a URL that had served 200 in under a
+second moments earlier -- the fetch was not slow, it was starved of event-loop
+time by PairX running synchronously in the handler.
+"""
+import json
+
+import cv2
+import httpx
+import numpy as np
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+
+from app.models.miewid import MiewidModel
+from app.routers import explain_router
+from app.utils import image_uri
+
+
+def _png_bytes():
+    """A real, decodable 8x8 PNG."""
+    ok, buf = cv2.imencode(".png", np.full((8, 8, 3), 127, np.uint8))
+    assert ok
+    return buf.tobytes()
+
+
+def _miewid():
+    m = MagicMock(spec=MiewidModel)
+    m.model = MagicMock()
+    return m
+
+
+def _client(responder):
+    """Test app whose shared fetch client is backed by `responder`."""
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+    app = FastAPI()
+    app.include_router(explain_router.router)
+    handler = MagicMock()
+    handler.get_model.side_effect = lambda mid: {"miewid-msv4.1": _miewid()}.get(mid)
+    handler.list_models.return_value = {"miewid-msv4.1": {}}
+    app.state.model_handler = handler
+    app.state.device = "cpu"
+    return TestClient(app, raise_server_exceptions=False)
+
+
+BODY = {
+    "image1_uris": ["https://wb.example/a.jpg"],
+    "bb1": [[0, 0, 8, 8]],
+    "image2_uris": ["https://wb.example/b.jpg"],
+    "bb2": [[0, 0, 8, 8]],
+    "model_id": "miewid-msv4.1",
+}
+
+
+def test_upstream_read_timeout_is_504_not_400():
+    """A slow Wildbook is retryable (504), not a caller error (400).
+
+    This is the incident: the same asset served 200 a second earlier, so
+    reporting 400 told Wildbook to give up on a request that would succeed.
+    """
+    def responder(request):
+        raise httpx.ReadTimeout("upstream stalled", request=request)
+
+    r = _client(responder).post("/explain/", json=BODY)
+    assert r.status_code == 504, r.text
+
+
+def test_upstream_5xx_is_502_not_400():
+    """A Wildbook 503 is an upstream failure, not a malformed request."""
+    def responder(request):
+        return httpx.Response(503)
+
+    r = _client(responder).post("/explain/", json=BODY)
+    assert r.status_code == 502, r.text
+
+
+def test_undecodable_body_is_400_without_opencv_internals():
+    """A 200 carrying an HTML error page is a clean 400, not a cv2 assertion.
+
+    Previously `cv2.imdecode` returned None and `cvtColor` raised
+    '(-215:Assertion failed) !_src.empty()', which leaked into the response.
+    """
+    def responder(request):
+        return httpx.Response(200, content=b"<html>upstream error</html>")
+
+    r = _client(responder).post("/explain/", json=BODY)
+    assert r.status_code == 400, r.text
+    # The hardened path names the URI that failed; the old inline fetch
+    # echoed only the exception, so this also proves which path ran.
+    assert "wb.example" in r.text, r.text
+    assert "Assertion failed" not in r.text
+    assert "cvtColor" not in r.text
+
+
+def test_fetch_failure_does_not_consume_an_inference_slot(monkeypatch):
+    """A request that dies at fetch must never hold the PairX semaphore."""
+    class SpySemaphore:
+        acquired = False
+
+        async def __aenter__(self):
+            SpySemaphore.acquired = True
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(explain_router, "explain_semaphore", SpySemaphore())
+
+    def responder(request):
+        raise httpx.ReadTimeout("upstream stalled", request=request)
+
+    r = _client(responder).post("/explain/", json=BODY)
+    assert r.status_code == 504, r.text
+    assert SpySemaphore.acquired is False
+
+
+def _counting(responder):
+    """Wrap a responder so the test can assert how many fetches happened."""
+    calls = []
+
+    def wrapped(request):
+        calls.append(str(request.url))
+        return responder(request)
+
+    return wrapped, calls
+
+
+def test_oversized_batch_is_rejected_before_any_fetch():
+    """A batch over MAX_BATCH_SIZE must 400 without touching the network.
+
+    Every image fetched takes a slot from the process-wide admission gate
+    that /extract, /predict, /classify and /pipeline also queue on, so a
+    request already known to be invalid must not consume any.
+    """
+    responder, calls = _counting(lambda r: httpx.Response(200, content=_png_bytes()))
+    n = explain_router.MAX_BATCH_SIZE + 1
+    body = dict(BODY,
+                image1_uris=[f"https://wb.example/a{i}.jpg" for i in range(n)],
+                bb1=[[0, 0, 8, 8]] * n,
+                image2_uris=[f"https://wb.example/b{i}.jpg" for i in range(n)],
+                bb2=[[0, 0, 8, 8]] * n)
+
+    r = _client(responder).post("/explain/", json=body)
+    assert r.status_code == 400, r.text
+    assert calls == [], f"fetched {len(calls)} images before rejecting the batch"
+
+
+def test_mismatched_pair_counts_rejected_before_any_fetch():
+    """Unequal image1/image2 counts are a permanent caller error."""
+    responder, calls = _counting(lambda r: httpx.Response(200, content=_png_bytes()))
+    body = dict(BODY,
+                image1_uris=["https://wb.example/a1.jpg", "https://wb.example/a2.jpg"],
+                bb1=[[0, 0, 8, 8]] * 2,
+                image2_uris=[f"https://wb.example/b{i}.jpg" for i in range(3)],
+                bb2=[[0, 0, 8, 8]] * 3)
+
+    r = _client(responder).post("/explain/", json=body)
+    assert r.status_code == 400, r.text
+    assert calls == [], f"fetched {len(calls)} images before rejecting the pairing"
+
+
+def test_non_finite_bbox_is_400_not_500():
+    """NaN survives Pydantic and every `x < 0` test, then breaks int().
+
+    It must stay a caller error. As a 500 it would be retried by Wildbook
+    forever against a request that can never succeed.
+    """
+    responder, _ = _counting(lambda r: httpx.Response(200, content=_png_bytes()))
+    body = dict(BODY, bb1=[[0, 0, float("nan"), 8]])
+    # json.dumps emits a bare NaN, which json.loads (and so FastAPI) accepts;
+    # the test client's own encoder refuses it, hence the raw body.
+    raw = json.dumps(body)
+    assert "NaN" in raw
+
+    r = _client(responder).post(
+        "/explain/", content=raw, headers={"content-type": "application/json"})
+    assert r.status_code == 400, r.text
+
+
+def test_opencv_undecodable_body_is_400():
+    """Bytes PIL accepts but OpenCV cannot decode hit the `image is None` guard.
+
+    Distinct from the HTML case, which check_image_header() rejects earlier --
+    this is the only test that reaches cv2.imdecode returning None.
+    """
+    def responder(request):
+        return httpx.Response(200, content=_png_bytes())
+
+    client = _client(responder)
+    with patch.object(explain_router.cv2, "imdecode", return_value=None):
+        r = client.post("/explain/", json=BODY)
+    assert r.status_code == 400, r.text
+    assert "Assertion failed" not in r.text

--- a/tests/test_explain_router_fetch.py
+++ b/tests/test_explain_router_fetch.py
@@ -13,6 +13,8 @@ second moments earlier -- the fetch was not slow, it was starved of event-loop
 time by PairX running synchronously in the handler.
 """
 import json
+import threading
+import time
 
 import cv2
 import httpx
@@ -121,6 +123,73 @@ def test_fetch_failure_does_not_consume_an_inference_slot(monkeypatch):
     r = _client(responder).post("/explain/", json=BODY)
     assert r.status_code == 504, r.text
     assert SpySemaphore.acquired is False
+
+
+def test_a_running_explain_does_not_starve_concurrent_requests():
+    """The incident, end to end: a slow PairX must not stall the event loop.
+
+    Timestamps are absolute and recorded inside the handlers. Measuring
+    latency from the caller cannot detect this: if the loop is blocked, the
+    caller's own await does not resume until the block ends, so it reports
+    zero latency after the fact. Verified to discriminate -- with PairX
+    called inline this probe is served 1002 ms after PairX begins (the full
+    blocking call), versus 241 ms offloaded (the 250 ms we wait before
+    probing).
+    """
+    import asyncio
+
+    pairx_seconds = 1.0
+    started = threading.Event()
+    marks = {}
+
+    image_uri.init_image_fetch(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, content=_png_bytes())))
+
+    app = FastAPI()
+    app.include_router(explain_router.router)
+
+    @app.get("/probe")
+    async def probe():
+        marks["probe_served"] = time.monotonic()
+        return {"ok": True}
+
+    handler = MagicMock()
+    handler.get_model.side_effect = lambda mid: {"miewid-msv4.1": _miewid()}.get(mid)
+    handler.list_models.return_value = {"miewid-msv4.1": {}}
+    app.state.model_handler = handler
+    app.state.device = "cpu"
+
+    def slow_pairx(*a, **k):
+        marks["pairx_started"] = time.monotonic()
+        started.set()
+        time.sleep(pairx_seconds)
+        return [np.zeros((4, 4, 3), np.uint8)]
+
+    async def scenario():
+        async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://t") as c:
+            task = asyncio.create_task(c.post("/explain/", json=BODY))
+            # Synchronize on PairX having actually begun. A fixed sleep can
+            # elapse before the request reaches PairX on a cold run, which
+            # would serve /probe first and make the comparison below
+            # trivially -- and silently -- true.
+            deadline = time.monotonic() + 10
+            while not started.is_set() and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+            probe_response = await c.get("/probe")
+            return await task, probe_response
+
+    with patch.object(explain_router, "run_pairx", slow_pairx):
+        explain_response, probe_response = asyncio.run(scenario())
+
+    assert explain_response.status_code == 200, explain_response.text
+    assert probe_response.status_code == 200
+    assert started.is_set(), "PairX never ran; the test proved nothing"
+    waited = marks["probe_served"] - marks["pairx_started"]
+    assert waited >= 0, "probe was served before PairX began"
+    assert waited < pairx_seconds * 0.9, (
+        f"probe was served {waited:.2f}s after PairX began; the event loop "
+        f"was starved for the duration of the inference")
 
 
 def _counting(responder):


### PR DESCRIPTION
## What

Two independent fixes for the Flukebook intermittent-400 incident of 2026-08-28, plus the review findings that came out of them.

1. **`/explain` joins the hardened image-fetch path.** It was the one router #39 did not migrate and still used an inline `httpx.AsyncClient()` — httpx's 5s default, reachable by no env var — inside a bare `except Exception` mapping every failure to 400.
2. **PairX runs off the event loop** (`run_in_threadpool`). Inline it pinned the loop for the whole inference, starving concurrent image fetches on that worker.

## Why

From production logs:

```
17:32:45,179  httpx GET .../NBW20170806NBW16826.JPG "HTTP/1.1 200"   <- same asset, <1s
              POST /explain/ 200 OK
17:33:44,441  Image fetch failed (504, TimeoutError, 60001 ms): .../NBW20170806NBW16826.JPG
              POST /extract/ 504 Gateway Timeout
              POST /explain/ 400 Bad Request
```

Flukebook served that exact file in under a second. A second fetch of the same URL, already in flight, then burned a full 60 s and died on `IMAGE_FETCH_TOTAL_DEADLINE_S`. That time was not spent waiting on Flukebook — it was spent not being scheduled, by the `/explain/` sitting between the two log lines. The next `/explain/` then tripped its own 5 s default and returned 400, which Wildbook does not retry.

## Also fixed (from review)

- `process_asyncio_result` re-wrapped every `asyncio.gather` result as 400, which would have flattened the new 504 straight back.
- Explicit `image is None` guard after `cv2.imdecode` — the OpenCV `!_src.empty()` assertion used to reach the caller as the entire error detail.
- Pairing, batch size and every bbox/theta are now validated **before** the fetch fan-out, so an already-invalid request takes no slots from the gate the other routers queue on.
- Non-finite bbox/theta rejected: a bare `NaN` survives `json.loads` and every `x < 0` test, then broke `int()` during cropping. Confirmed reachable over the wire.

## Behaviour changes

- `MAX_CONCURRENT_EXPLANATIONS` 2 → 1. The offload makes two explains genuinely parallel against one shared model, and PAIR-X backpropagates, so they would race on `.grad` and on `zero_grad()`. Inline execution already serialized them, so observed concurrency is unchanged.
- Local paths go through the shared resolver, which does not expand a leading `~`. URLs, absolute and relative paths, and (newly) data URIs are unaffected.
- No new env vars. The `IMAGE_FETCH_*` knobs now apply to `/explain`; defaults are unchanged.

## Testing

`tests/test_explain_router_fetch.py`, 9 tests, each watched fail before implementing. Full suite 295 passed.

The concurrency test records absolute timestamps inside the handlers and synchronizes on PairX having started — measuring from the caller cannot detect this, because a blocked loop does not resume the caller's own `await` until the block ends. Verified to discriminate: the probe is served **1002 ms** after PairX begins with the call inline, versus **~10 ms** offloaded.

Two earlier tests of mine were false greens and were caught in review: a thread-identity assertion (`TestClient` runs handlers on an `asyncio-portal` thread, so it held even inline — deleted) and an HTML-body test that never reached the guard it claimed to cover (relabelled, with a real `cv2.imdecode` → `None` test added).

## Not addressed — pre-existing, out of scope

- The OOM splitter in `run_pairx` is unreachable and broken: `.shape` on a list, `midpoint == 0` at batch size 1, and a string prefix that never matches a real OOM message.
- `--workers 4` still permits four concurrent PairX passes on one GPU across processes; a per-process semaphore cannot bound that. See #28, which needs a rebase — `cedbcd2` rewrote the compose lines it targets.
- The 1-vs-N side has no batch cap. Capping it would newly reject requests that work today.
- `fetch_image_for_request` maps a 200-with-unparseable-body to 400 rather than 502. That is shared across four routers and covered by `tests/test_image_fetch_mapping.py`; changing it is a cross-router design decision.

## Review

Codex (`codex exec`), 2 rounds, converged with no Major findings. Round 1 raised 7 items; 4 were accepted and fixed, 3 were pushed back on with reasoning that round 2 confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)