### PR TITLE
fix(explain): log the exception behind run_pairx's generic 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- `run_pairx` logs the exception behind its generic 500. It is one of only two
+  lines producing `{"detail":"Internal Server Error"}`, and was the one that
+  logged nothing -- so a PairX failure was undiagnosable from the logs. The
+  wire response is unchanged and still opaque; the cause and the batch shape
+  (which is what a CUDA OOM turns on) now reach the log.
+
 - `/explain/` (PairX) joins the image-fetch resilience path. It was the one
   router PR #39 did not migrate and still used an inline `httpx.AsyncClient()`
   -- httpx's 5s default timeout, no env knob -- inside a bare

--- a/app/routers/explain_router.py
+++ b/app/routers/explain_router.py
@@ -324,6 +324,16 @@ def run_pairx(imgs1_transformed, imgs2_transformed, imgs1, imgs2, model, layer_k
                     layer_key, k_lines, k_colors, visualization_type)
             return first_half + second_half
         else:
+            # The response stays deliberately opaque, so the cause has to go
+            # somewhere. Without this the 500 is undiagnosable: it is one of
+            # only two lines producing this exact body, and the other one
+            # (process_asyncio_result) is the only one that logged.
+            # Batch shape is included because the failure this most often
+            # hides is a CUDA OOM, whose likelihood depends on it.
+            logger.exception(
+                "PAIR-X inference failed (layer_key=%s, pairs=%d, k_lines=%d, "
+                "k_colors=%d)", layer_key, len(imgs1_transformed), k_lines,
+                k_colors)
             raise HTTPException(status_code=500, detail=f"Internal Server Error")
     finally:
         # PAIR-X backward() accumulates .grad on model params — clear to prevent VRAM growth

--- a/tests/test_explain_router_pairx_errors.py
+++ b/tests/test_explain_router_pairx_errors.py
@@ -1,0 +1,59 @@
+"""run_pairx must not swallow the exception behind its generic 500.
+
+Flukebook, 2026-08-28 19:20: Wildbook logged
+`postRaw() on .../explain/ failed with code=500 {"detail":"Internal Server
+Error"}` and the retry succeeded. Two lines in this router produce that exact
+body -- process_asyncio_result, which logs a traceback, and run_pairx's
+generic `except`, which logged nothing at all. When the failure is the second
+one there is no way to tell what actually broke.
+"""
+import logging
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from fastapi import HTTPException
+
+from app.routers import explain_router
+
+
+def _run(raises):
+    """Drive run_pairx with `explain` replaced by something that fails."""
+    model = MagicMock()
+    model.named_modules.return_value = [("backbone.blocks.3", MagicMock())]
+    tensors = [torch.zeros(1, 3, 4, 4)]
+    images = [np.zeros((4, 4, 3), np.uint8)]
+
+    def boom(*a, **k):
+        raise raises
+
+    with patch.object(explain_router, "explain", boom):
+        return explain_router.run_pairx(
+            tensors, tensors, images, images, model,
+            "backbone.blocks.3", 20, 5, "only_colors")
+
+
+def test_pairx_failure_is_logged_with_its_cause(caplog):
+    """The 500 stays generic on the wire; the cause must reach the log."""
+    cause = RuntimeError(
+        "CUDA out of memory. Tried to allocate 2.00 GiB. GPU 0 has a total "
+        "capacity of 23.68 GiB of which 1.12 GiB is free.")
+
+    with caplog.at_level(logging.ERROR, logger=explain_router.logger.name):
+        with pytest.raises(HTTPException) as excinfo:
+            _run(cause)
+
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Internal Server Error", \
+        "the wire response must stay generic -- no internals leak to the caller"
+    assert "CUDA out of memory" in caplog.text, \
+        "run_pairx swallowed the cause; the 500 is undiagnosable"
+    assert "Traceback" in caplog.text, "the log entry needs the traceback"
+
+
+def test_pairx_failure_does_not_leak_internals_to_the_caller():
+    """Whatever we log, the response body stays opaque."""
+    with pytest.raises(HTTPException) as excinfo:
+        _run(RuntimeError("/opt/secret/path exploded"))
+    assert "secret" not in str(excinfo.value.detail)


### PR DESCRIPTION
## What

One `logger.exception(...)` in `run_pairx`'s generic `except`. Diagnostic only — no status code, response body, or control-flow change.

## Why

From production, 2026-08-28 19:20 — Wildbook:

```
WARNING: postRaw() on https://kaiju.dyn.wildme.io:5050/explain/ failed with code=500
{"detail":"Internal Server Error"}
```

The retry then succeeded, so the failure is transient. But exactly two lines in `explain_router.py` produce that exact body:

| source | logged? |
|---|---|
| `process_asyncio_result` | yes, full traceback |
| `run_pairx`'s generic `except` | **nothing at all** |

When it's the second one there is nothing in the log to distinguish them, and no way to learn what actually broke. This closes that.

## What it looks like

```
2026-08-28 19:20:31,004 - app.routers.explain_router - ERROR - PAIR-X inference failed (layer_key=backbone.blocks.3, pairs=4, k_lines=20, k_colors=5)
Traceback (most recent call last):
  File "/app/app/routers/explain_router.py", line 306, in run_pairx
    pairx_imgs = explain(
RuntimeError: CUDA out of memory. Tried to allocate 2.00 GiB. GPU 0 has a total capacity of 23.68 GiB of which 1.12 GiB is free.
```

Batch shape is included because the failure this most often hides is a CUDA OOM, whose likelihood turns on it.

## Note on the dead OOM branch

The `except` directly above tests `str(e).startswith("torch.cuda.OutOfMemoryError:")`, which never matches a real OOM — the message begins `CUDA out of memory. Tried to allocate...`. So a genuine OOM already falls through to this generic 500 instead of being split and retried. That branch is also broken independently (`.shape` on a list, `midpoint == 0` at batch size 1). **Left alone here** — this PR only makes it visible. Worth its own change once the logs confirm whether OOM is what's actually happening.

## Testing

`tests/test_explain_router_pairx_errors.py` — 2 tests, watched fail first (`caplog.text` was empty, proving the swallow). Asserts the cause and traceback reach the log **and** that the wire response stays opaque. Full suite 297 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)