### PR TITLE
fix(explain): stop a concurrent forward hijacking PairX's feature-map capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+- Fixed `/explain/` 500s caused by a concurrent forward hijacking PairX's
+  feature-map capture. PAIR-X registers a `register_forward_hook` on a
+  submodule of the *shared* MiewID instance (pairx/core.py:23-43); that hook
+  fires for every forward through the submodule, from any thread, until it is
+  removed. A `/extract` or `/pipeline` forward landing between PairX's own
+  forward and `handle.remove()` replaced the captured tensor with a no-grad
+  one, and PairX's backward then died with `element 0 of tensors does not
+  require grad and does not have a grad_fn`. `MiewidModel` now carries an
+  `inference_lock` held by `extract_embeddings` across its forward and by
+  `/explain` across the whole PairX call. The lock is taken inside the worker
+  thread, so the event loop is never blocked. Latent until PairX moved off the
+  event loop, which had been serializing these by accident.
+
 - `run_pairx` logs the exception behind its generic 500. It is one of only two
   lines producing `{"detail":"Internal Server Error"}`, and was the one that
   logged nothing -- so a PairX failure was undiagnosable from the logs. The

--- a/app/models/miewid.py
+++ b/app/models/miewid.py
@@ -14,6 +14,7 @@ from albumentations.pytorch import ToTensorV2
 from PIL import Image
 import numpy as np
 import io
+import threading
 from app.utils.checkpoint_utils import get_checkpoint_path
 from app.utils.helpers import get_chip_from_img
 
@@ -65,6 +66,21 @@ class MiewidModel(BaseModel):
         self.device = "cuda"
         self.preprocess = None
         self.use_checkpoint = False
+        # Serializes forwards through this instance across routers.
+        #
+        # PAIR-X (/explain) captures its feature map with a forward hook
+        # registered on a submodule of this very object (pairx/core.py:23-43),
+        # and that hook fires for EVERY forward through the submodule, from any
+        # thread, until it is removed. A /extract or /pipeline forward landing
+        # in that window -- same model id, same instance, under no_grad --
+        # overwrites the captured tensor with one that has no grad_fn, and
+        # PAIR-X's backward then dies with "element 0 of tensors does not
+        # require grad".
+        #
+        # A plain Lock is sufficient: run_pairx_locked acquires once and
+        # run_pairx's OOM recursion stays inside that single acquisition,
+        # never reacquiring. Nothing takes this lock twice on one thread.
+        self.inference_lock = threading.Lock()
 
     def load(self, model_path: str = "", device: str = "cuda", **kwargs) -> None:
         self.device = device
@@ -199,8 +215,10 @@ class MiewidModel(BaseModel):
             input_tensor = augmented["image"]
             input_batch = input_tensor.unsqueeze(0).to(self.device)
             
-            # Extract embeddings
-            with torch.no_grad():
+            # Extract embeddings. The lock is held only across the forward,
+            # not the decode/preprocess above it, so a slow image never blocks
+            # another endpoint's inference.
+            with self.inference_lock, torch.no_grad():
                 embeddings = self.model(input_batch)
             
             # Convert to numpy and return

--- a/app/routers/explain_router.py
+++ b/app/routers/explain_router.py
@@ -265,6 +265,17 @@ def process_asyncio_result(result):
     image, transform = result
     return image, transform
 
+def run_pairx_locked(lock, *args, **kwargs):
+    """Run PAIR-X holding `lock`, excluding other forwards on the same model.
+
+    Called through run_in_threadpool, so the lock is acquired on the worker
+    thread and never on the event loop -- blocking there would reintroduce
+    the request starvation that moving PAIR-X off the loop fixed.
+    """
+    with lock:
+        return run_pairx(*args, **kwargs)
+
+
 def run_pairx(imgs1_transformed, imgs2_transformed, imgs1, imgs2, model, layer_key, 
         k_lines, k_colors, visualization_type):
     """Run PAIR-X on provided images with given parameters.
@@ -461,8 +472,14 @@ async def read_items(
             # the 2026-08-28 Flukebook incident, where a sibling /extract/
             # fetch blew its 60s deadline on an asset that had served 200 in
             # under a second, and the next /explain/ 400'd on its own timeout.
+            # model_entry.inference_lock excludes /extract and /pipeline
+            # forwards on this same MiewID instance for the whole call: PAIR-X
+            # captures its feature map with a forward hook on a submodule of
+            # it, and any other forward through that submodule while the hook
+            # is registered overwrites the capture with a no-grad tensor.
             visualizations = await run_in_threadpool(
-                run_pairx, image1s_transformed, image2s_transformed,
+                run_pairx_locked, model_entry.inference_lock,
+                image1s_transformed, image2s_transformed,
                 image1s, image2s, model, body.layer_key,
                 body.k_lines, body.k_colors, body.visualization_type)
         else:

--- a/tests/test_explain_router_fetch.py
+++ b/tests/test_explain_router_fetch.py
@@ -39,6 +39,8 @@ def _png_bytes():
 def _miewid():
     m = MagicMock(spec=MiewidModel)
     m.model = MagicMock()
+    # Real instances get this in __init__; spec= only exposes class attrs.
+    m.inference_lock = threading.RLock()
     return m
 
 

--- a/tests/test_explain_router_model_lock.py
+++ b/tests/test_explain_router_model_lock.py
@@ -1,0 +1,243 @@
+"""PairX's forward hook must not see another request's forward.
+
+Flukebook, 2026-08-28 20:06 -- `RuntimeError: element 0 of tensors does not
+require grad and does not have a grad_fn` from
+pairx/core.py:140 `intermediate_fm.backward(...)`.
+
+pairx/core.py:23-43 captures the feature map with a forward hook on the
+SHARED model submodule:
+
+    handles.append(submodule.register_forward_hook(get_intermediate_hook(k)))
+    embedding = model(img)      # captures a grad-bearing fm
+                                # <-- any other forward here overwrites it
+    for handle in handles: handle.remove()
+
+/extract and /pipeline run `self.model(x)` under torch.no_grad() on that same
+MiewID instance. A forward landing in that window replaces the captured tensor
+with one that has no grad_fn, and PairX's backward then fails.
+
+Before the PairX offload (#42) run_pairx ran inline on the event loop, which
+blocked everything else and made the window unreachable by accident. The
+offload removed that, so the exclusion now has to be explicit.
+"""
+import threading
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from app.models.miewid import MiewidModel
+
+
+class _SharedBackbone(nn.Module):
+    """Stands in for MiewID: one instance, reachable by both endpoints."""
+
+    def __init__(self):
+        super().__init__()
+        self.blocks = nn.Sequential(nn.Conv2d(3, 4, 3, padding=1), nn.ReLU())
+
+    def forward(self, x):
+        return self.blocks(x)
+
+
+def test_concurrent_forward_corrupts_an_unguarded_hook():
+    """Characterizes the bug itself, so the guard below is not vacuous."""
+    model = _SharedBackbone()
+    captured = {}
+    handle = model.blocks[0].register_forward_hook(
+        lambda m, i, o: captured.__setitem__("fm", o))
+
+    img = torch.randn(1, 3, 8, 8, requires_grad=True)
+    model(img)
+    assert captured["fm"].grad_fn is not None, "PairX's own forward is grad-bearing"
+
+    with torch.no_grad():                    # the interloping /extract forward
+        model(torch.randn(1, 3, 8, 8))
+    handle.remove()
+
+    assert captured["fm"].grad_fn is None
+    with pytest.raises(RuntimeError, match="does not require grad"):
+        captured["fm"].backward(gradient=torch.zeros_like(captured["fm"]))
+
+
+def test_miewid_exposes_a_lock_excluding_concurrent_forwards():
+    """The model instance must offer the mutual exclusion both callers use."""
+    m = MiewidModel()
+    assert hasattr(m, "inference_lock"), \
+        "MiewidModel needs a lock /explain and /extract can share"
+    assert m.inference_lock.acquire(blocking=False)
+    m.inference_lock.release()
+
+
+def test_extract_embeddings_holds_the_lock_during_its_forward():
+    """/extract must not run a forward while PairX holds the model."""
+    m = MiewidModel()
+    m.device = "cpu"
+    m.model = _SharedBackbone()
+    m.preprocess = lambda image: {
+        "image": torch.zeros(3, 8, 8)}
+
+    forward_ran = threading.Event()
+    preprocessed = threading.Event()
+    original = m.model.forward
+    m.model.forward = lambda x: (forward_ran.set(), original(x))[1]
+    # Signals that the worker has finished decode/preprocess and is at the
+    # forward. Without this the assertion below could pass merely because a
+    # slow PIL decode had not reached the lock yet.
+    m.preprocess = lambda image: (preprocessed.set(),
+                                  {"image": torch.zeros(3, 8, 8)})[1]
+
+    import io
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8)).save(buf, format="PNG")
+
+    m.inference_lock.acquire()               # stand in for PairX holding it
+    try:
+        t = threading.Thread(target=lambda: m.extract_embeddings(buf.getvalue()))
+        t.start()
+        assert preprocessed.wait(5), \
+            "/extract never reached the forward; the test would be vacuous"
+        assert not forward_ran.wait(0.5), \
+            "/extract ran a forward while the model was held by another caller"
+    finally:
+        m.inference_lock.release()
+        t.join(5)
+    assert forward_ran.wait(5), "/extract must proceed once the lock is released"
+
+
+def test_explain_holds_the_model_lock_across_pairx():
+    """The /explain path must hold the model for the whole PairX call.
+
+    And it must take the lock inside the worker thread, never on the event
+    loop -- a threading lock acquired in the handler would reintroduce the
+    starvation #42 fixed.
+    """
+    import httpx
+    from unittest.mock import MagicMock, patch
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import cv2
+
+    from app.routers import explain_router
+    from app.utils import image_uri
+
+    ok, buf = cv2.imencode(".png", np.full((8, 8, 3), 127, np.uint8))
+    png = buf.tobytes()
+
+    entry = MagicMock(spec=MiewidModel)
+    entry.model = MagicMock()
+    entry.inference_lock = threading.RLock()
+
+    observed = {}
+    loop_thread = {}
+
+    real_process_image = explain_router.process_image
+
+    async def recording_process_image(*a, **k):
+        # process_image is awaited on the event loop, so this is that thread.
+        loop_thread["t"] = threading.current_thread()
+        return await real_process_image(*a, **k)
+
+    def fake_run_pairx(*a, **k):
+        # Held by us, on this thread -- so prove another thread cannot take it.
+        taken = []
+        t = threading.Thread(
+            target=lambda: taken.append(
+                entry.inference_lock.acquire(blocking=False)))
+        t.start(); t.join(5)
+        observed["excluded"] = taken == [False]
+        observed["thread"] = threading.current_thread()
+        return [np.zeros((4, 4, 3), np.uint8)]
+
+    image_uri.init_image_fetch(transport=httpx.MockTransport(
+        lambda r: httpx.Response(200, content=png)))
+    app = FastAPI()
+    app.include_router(explain_router.router)
+    handler = MagicMock()
+    handler.get_model.side_effect = lambda mid: {"miewid-msv4.1": entry}.get(mid)
+    handler.list_models.return_value = {"miewid-msv4.1": {}}
+    app.state.model_handler = handler
+    app.state.device = "cpu"
+
+    with patch.object(explain_router, "run_pairx", fake_run_pairx), \
+         patch.object(explain_router, "process_image", recording_process_image):
+        r = TestClient(app, raise_server_exceptions=False).post("/explain/", json={
+            "image1_uris": ["https://wb.example/a.jpg"], "bb1": [[0, 0, 8, 8]],
+            "image2_uris": ["https://wb.example/b.jpg"], "bb2": [[0, 0, 8, 8]],
+            "model_id": "miewid-msv4.1"})
+
+    assert r.status_code == 200, r.text
+    assert observed.get("excluded") is True, \
+        "another thread could run a forward while PairX held the model"
+    # Compared against the event-loop thread, NOT main_thread(): TestClient
+    # runs handlers on an asyncio-portal thread, so a main_thread() check
+    # would hold even for an inline call and prove nothing.
+    assert observed["thread"] is not loop_thread["t"], \
+        "PairX took the lock on the event loop; that reintroduces starvation"
+
+
+def test_concurrent_extract_cannot_corrupt_pairx_capture():
+    """The invariant, end to end, through the real extract_embeddings path.
+
+    A PairX-shaped hook window is held open on a shared model while a genuine
+    /extract call runs against the same instance. The captured feature map
+    must still carry its grad_fn -- i.e. the tensor PairX backwards through is
+    its own forward's, not /extract's.
+    """
+    import io
+    import time
+    from PIL import Image
+
+    from unittest.mock import patch as _patch
+
+    from app.routers import explain_router
+    from app.routers.explain_router import run_pairx_locked
+
+    m = MiewidModel()
+    m.device = "cpu"
+    m.model = _SharedBackbone()
+    m.preprocess = lambda image: {"image": torch.zeros(3, 8, 8)}
+
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8)).save(buf, format="PNG")
+    payload = buf.getvalue()
+
+    captured = {}
+    window_open = threading.Event()
+
+    def pairx_shaped(*a, **k):
+        """Mirrors pairx/core.py:23-43, with the window held open."""
+        handle = m.model.blocks[0].register_forward_hook(
+            lambda mod, i, o: captured.__setitem__("fm", o))
+        try:
+            m.model(torch.randn(1, 3, 8, 8, requires_grad=True))
+            window_open.set()
+            time.sleep(0.5)          # /extract gets its chance here
+        finally:
+            handle.remove()
+        return captured["fm"]
+
+    extracted = []
+    t = threading.Thread(
+        target=lambda: extracted.append(m.extract_embeddings(payload)))
+
+    def start_extract_once_open():
+        window_open.wait(5)
+        t.start()
+
+    starter = threading.Thread(target=start_extract_once_open)
+    starter.start()
+
+    with _patch.object(explain_router, "run_pairx", pairx_shaped):
+        fm = run_pairx_locked(m.inference_lock)
+
+    starter.join(5)
+    t.join(5)
+
+    assert extracted, "/extract must still complete, just not during the window"
+    assert fm.grad_fn is not None, (
+        "a concurrent /extract forward overwrote PairX's captured feature map; "
+        "backward() would fail with 'does not require grad'")
+    fm.backward(gradient=torch.zeros_like(fm))   # the call that used to raise

--- a/tests/test_explain_router_model_resolution.py
+++ b/tests/test_explain_router_model_resolution.py
@@ -8,6 +8,7 @@ registry held only `miewid-msv4_v3`, every request failed -- allowlisted
 names 500'd because they were not loaded, and the real name was rejected 400
 because it was not allowlisted.
 """
+import threading
 import pathlib
 from unittest.mock import MagicMock, patch
 
@@ -61,6 +62,8 @@ def _body(model_id, **over):
 def _miewid():
     m = MagicMock(spec=MiewidModel)
     m.model = MagicMock()
+    # Real instances get this in __init__; spec= only exposes class attrs.
+    m.inference_lock = threading.RLock()
     return m
 
 

--- a/tests/test_pairx_offset_and_color.py
+++ b/tests/test_pairx_offset_and_color.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import threading
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -45,7 +46,10 @@ def _miewid_stub():
     type rather than on a model_id string, so these tests pass an object
     that satisfies `isinstance(..., MiewidModel)`.
     """
-    return MagicMock(spec=MiewidModel)
+    m = MagicMock(spec=MiewidModel)
+    # Real instances get this in __init__; spec= only exposes class attrs.
+    m.inference_lock = threading.RLock()
+    return m
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +266,7 @@ def test_extract_embeddings_uses_canonical_chip_helper():
     # Stand up a real MiewidModel instance but stub the heavy bits.
     model = MiewidModel.__new__(MiewidModel)
     model.device = "cpu"
+    model.inference_lock = threading.RLock()   # __new__ skips __init__
 
     fake_tensor = torch.zeros(3, 4, 4)
     captured = {}
@@ -353,6 +358,7 @@ def test_extract_embeddings_handles_zero_size_bbox_with_rotation():
 
     model = MiewidModel.__new__(MiewidModel)
     model.device = "cpu"
+    model.inference_lock = threading.RLock()   # __new__ skips __init__
     captured = {}
 
     def fake_preprocess(image):
@@ -387,6 +393,7 @@ def test_extract_embeddings_no_bbox_with_theta_uses_full_frame_helper():
 
     model = MiewidModel.__new__(MiewidModel)
     model.device = "cpu"
+    model.inference_lock = threading.RLock()   # __new__ skips __init__
     captured = {}
 
     def fake_preprocess(image):
@@ -410,6 +417,7 @@ def test_extract_embeddings_no_bbox_no_theta_uses_full_image():
 
     model = MiewidModel.__new__(MiewidModel)
     model.device = "cpu"
+    model.inference_lock = threading.RLock()   # __new__ skips __init__
     captured = {}
 
     def fake_preprocess(image):


### PR DESCRIPTION
## The bug

Production, Flukebook 2026-08-28 20:06 — `POST /explain/ 500`, retry succeeds. Surfaced by the logging added in #43:

```
ERROR - PAIR-X inference failed (layer_key=backbone.blocks.3, pairs=1, k_lines=20, k_colors=5)
Traceback (most recent call last):
  File "/app/app/routers/explain_router.py", line 306, in run_pairx
  File "/usr/local/lib/python3.10/dist-packages/pairx/core.py", line 140, in get_pixel_relevances
    intermediate_fm.backward(gradient=gradient.to(device), retain_graph=True)
RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```

## Root cause

PAIR-X captures its feature map with a **forward hook on the shared MiewID `nn.Module`** (`pairx/core.py:23-43`):

```python
handles.append(submodule.register_forward_hook(get_intermediate_hook(layer_key)))
embedding = model(img)        # captures a grad-bearing fm
                              # ← any other forward here overwrites it
for handle in handles: handle.remove()
```

The hook fires for **every** forward through that submodule, from any thread, until it is removed. `/extract` and `/pipeline` call `self.model(x)` under `torch.no_grad()` on the same instance — same model id, same object. A forward landing in that window replaces the captured tensor with one that has no `grad_fn`, and PairX's backward dies.

Reproduced deterministically:

```
after PairX forward    -> grad_fn: <ConvolutionBackward0 object at 0x...>
after /extract forward -> grad_fn: None
backward RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```

**This was latent until #42.** Run inline on the event loop, `run_pairx` blocked every other request for its whole duration, so nothing could execute a forward inside the hook window. Moving PairX to a worker thread removed that accidental mutual exclusion. `explain_semaphore` doesn't help — it bounds explains against each other, not against `/extract`.

## The fix

`MiewidModel` owns an `inference_lock`:

- `extract_embeddings` holds it **across its forward only**, not across decode/preprocess, so a slow image never blocks another endpoint's inference.
- `/explain` holds it **across the whole `run_pairx` call**, acquired inside the worker thread via `run_pairx_locked` — so the event loop is never blocked and the starvation #42 fixed does not come back.

A plain `Lock`, not `RLock`: `run_pairx_locked` acquires once and the OOM recursion stays inside that single acquisition.

## Scope checked

- No other production path forwards a shared MiewID instance. `/extract` and `/pipeline` both reach it via `extract_embeddings`; `MiewidModel.predict()` raises rather than forwarding; `wbia_compat_router`, `/classify` and `/predict` never touch it.
- PairX is restricted to `MiewidModel` by `resolve_pairx_model`, so no other shared model type is hook-exposed.
- **Concurrent `/extract` embeddings were never wrong.** zennit's `composite.context` mutates the model in place, so I checked whether it perturbs a concurrent forward's output — it's bit-identical. This was a crash, not silent corruption.

## Testing

`tests/test_explain_router_model_lock.py`, 5 tests, 302 in the suite. Each was watched fail first, and the two that matter most were verified to discriminate against the unfixed code:

- The end-to-end invariant test (a real `extract_embeddings` running against a held PairX hook window) **fails with the lock neutered**, with the production error.
- The offload test **fails when `run_in_threadpool` is patched to inline**. It compares against the recorded event-loop thread, deliberately **not** `threading.main_thread()` — `TestClient` runs handlers on an asyncio-portal thread, so a `main_thread()` check holds even for an inline call and proves nothing. That exact false green shipped in an earlier revision of #42 and was caught in review.
- `test_concurrent_forward_corrupts_an_unguarded_hook` is a characterization test that documents the mechanism and passes either way, labelled as such.

Fixtures in three existing test files gained `inference_lock`, since `MagicMock(spec=MiewidModel)` only exposes class attributes and two tests build the model via `__new__`.

## Review

Codex (`codex exec`, gpt-5.6-terra), 2 rounds. Round 1: converged, no Critical/Major, three Minor — a wrong `RLock` rationale and two tests that could pass vacuously. All three fixed. Round 2: converged with no findings.

🤖 Co-authored by [Claude Code](https://claude.com/claude-code) (Opus 5) and Codex (gpt-5.6-terra)