### PR TITLE
fix(image-fetch): resolve image URIs whose filename contains a bare '#'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+- Image URIs containing a bare `#` now resolve. `#` opens a URL fragment,
+  which is never sent to the server, so a filename like
+  `2000_174419#R8123A.jpg` was requested as `2000_174419` and 404'd -- which
+  the fetch path correctly, but unhelpfully, reported as a permanent 400.
+  `#` is now percent-encoded in the PATH of http(s) URIs, in both the shared
+  fetch path and `/wbia-compat`'s own loader. Only the path: never the
+  authority (a blanket replace turns `https://evil#@internal.example/a.jpg`
+  into a fetch against `internal.example`, retargeting a caller-supplied
+  request to a host the URL never named) and never after a real query, so a
+  genuine `?sig=x#frag` fragment still drops. Idempotent; `data:` URIs and
+  local paths never reach the normalizer. Trade-off: on a path-bearing URL a
+  genuine trailing fragment is now read as part of the filename and 404s. `?`
+  is deliberately not encoded -- query strings are legitimate.
+
 - Fixed `/explain/` 500s caused by a concurrent forward hijacking PairX's
   feature-map capture. PAIR-X registers a `register_forward_hook` on a
   submodule of the *shared* MiewID instance (pairx/core.py:23-43); that hook

--- a/app/routers/wbia_compat_router.py
+++ b/app/routers/wbia_compat_router.py
@@ -20,6 +20,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 import httpx
+
+from app.utils.image_uri import encode_bare_fragment
 import numpy as np
 from fastapi import APIRouter, BackgroundTasks, Request
 from pydantic import BaseModel
@@ -423,7 +425,9 @@ def _load_image(image_uri: str) -> Optional[bytes]:
     """Load image bytes from a URI (URL or local file path)."""
     try:
         if image_uri.startswith(("http://", "https://")):
-            resp = httpx.get(image_uri, timeout=30)
+            # A bare '#' in a filename would otherwise truncate the request
+            # at the fragment delimiter; see encode_bare_fragment.
+            resp = httpx.get(encode_bare_fragment(image_uri), timeout=30)
             resp.raise_for_status()
             return resp.content
         else:

--- a/app/utils/image_uri.py
+++ b/app/utils/image_uri.py
@@ -5,6 +5,7 @@ import base64
 import io
 import logging
 import os
+import re
 import stat as stat_module
 import time
 import warnings
@@ -93,6 +94,69 @@ def check_image_header(data: bytes) -> None:
             f"Image dimensions {width}x{height} exceed {max_pixels} pixel cap")
 
 
+def encode_bare_fragment(uri: str) -> str:
+    """Percent-encode a bare '#' inside a URL's PATH so it stays in the path.
+
+    '#' opens a fragment, which is client-side only and never sent to the
+    server, so a filename containing an unencoded '#' truncates the request
+    silently: Flukebook's `.../3c8f4264-.../2000_174419#R8123A.jpg` was
+    requested as `.../2000_174419` and 404'd (2026-08-28). Wildbook builds
+    these URLs without encoding the filename.
+
+    Only the path is rewritten -- never the authority, and never after a real
+    query begins:
+
+      * `https://h/dir/2000_174419#R8123A.jpg` -> path `/dir/2000_174419%23R8123A.jpg`
+      * `https://h/a#b.jpg?sig=x`              -> path `/a%23b.jpg`, query `sig=x`
+      * `https://h/img.jpg?sig=x#frag`         -> unchanged; a '#' after the
+        query is a genuine fragment and stays one
+      * `https://evil#@internal.example/a.jpg` -> unchanged. Here '#' ends the
+        authority, so there is no path to fix. A blanket replace would turn
+        this into userinfo `evil%23` on host `internal.example` -- sending a
+        caller-supplied fetch to a DIFFERENT HOST than the URL names.
+
+    Idempotent: an already-encoded '%23' contains no '#'.
+
+    Trade-off: on a path-bearing URL a genuine trailing fragment is now read
+    as part of the filename and will 404. A fragment is meaningless for a
+    binary image fetch and Wildbook has no path that appends one, so this
+    reading is right for the producers we serve. No non-heuristic rule can
+    separate the two intents; the real fix belongs where the URL is built.
+
+    '?' has the same class of problem and is deliberately NOT encoded: query
+    strings are legitimate and common (signed URLs), so blanket-encoding
+    would break them.
+
+    Contract: absolute http(s) URLs only. A scheme-relative input ('//h/a#b')
+    is returned unchanged rather than guessed at -- both call sites gate on
+    an 'http://' or 'https://' prefix, so one cannot reach here.
+    """
+    if '#' not in uri:
+        return uri
+    scheme_sep = uri.find('://')
+    if scheme_sep == -1:
+        return uri
+    authority_start = scheme_sep + 3
+    delimiter = re.search(r'[/?#]', uri[authority_start:])
+    if delimiter is None or delimiter.group() != '/':
+        # No path component: the '#' terminates the authority (or none is
+        # present). Nothing here is a filename, so leave it entirely alone.
+        return uri
+    path_start = authority_start + delimiter.start()
+    head, rest = uri[:path_start], uri[path_start:]
+    query_at = rest.find('?')
+    if query_at == -1:
+        fixed = rest.replace('#', '%23')
+    else:
+        fixed = rest[:query_at].replace('#', '%23') + rest[query_at:]
+    if fixed == rest:
+        return uri
+    encoded = head + fixed
+    logger.info("Encoded bare '#' in image URI path: %s",
+                sanitize_uri_for_logging(encoded))
+    return encoded
+
+
 async def _fetch_url_bytes(uri: str) -> bytes:
     """Stream a URL through the shared client, enforcing the byte cap."""
     max_bytes = _settings["max_image_bytes"]
@@ -127,7 +191,8 @@ async def resolve_image_uri(uri: str) -> bytes:
     elif uri.startswith(('http://', 'https://')):
         _ensure_initialized()
         return await asyncio.wait_for(
-            _fetch_url_bytes(uri), timeout=_settings["total_deadline_s"])
+            _fetch_url_bytes(encode_bare_fragment(uri)),
+            timeout=_settings["total_deadline_s"])
     else:
         _ensure_initialized()
         file_path = Path(uri)

--- a/tests/test_image_fetch_bare_fragment.py
+++ b/tests/test_image_fetch_bare_fragment.py
@@ -1,0 +1,174 @@
+"""A bare '#' in an image filename must not truncate the request.
+
+Flukebook, 2026-08-28 19:20:
+
+    httpx GET .../3c8f4264-.../2000_174419#R8123A.jpg "HTTP/1.1 404"
+    Image fetch failed (400, HTTPStatusError, 47 ms): .../2000_174419#R8123A.jpg
+    POST /extract/ 400 Bad Request
+
+'#' is the fragment delimiter, so httpx sent only
+`/wildbook_data_dir/3/c/<uuid>/2000_174419` and Flukebook 404'd on the
+truncated path. The file on disk is named `2000_174419#R8123A.jpg`; the '#'
+has to reach the server percent-encoded.
+
+Wildbook builds these URLs without encoding the filename, which is the real
+upstream fix. This makes ml-service resolve them anyway.
+"""
+import asyncio
+
+import httpx
+
+from app.utils import image_uri
+
+PNG = bytes.fromhex("89504e470d0a1a0a") + b"\x00" * 64
+
+
+def _capture():
+    """A transport that records the path each request actually asks for."""
+    seen = {}
+
+    def responder(request):
+        seen["path"] = request.url.path
+        seen["raw_path"] = request.url.raw_path.decode()
+        return httpx.Response(200, content=PNG)
+
+    return responder, seen
+
+
+def test_bare_hash_in_filename_reaches_the_server_encoded():
+    responder, seen = _capture()
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+
+    asyncio.run(image_uri.resolve_image_uri(
+        "https://wb.example/wildbook_data_dir/3/c/uuid/2000_174419#R8123A.jpg"))
+
+    assert seen["path"].endswith("2000_174419#R8123A.jpg"), \
+        f"request was truncated at the '#': {seen['path']}"
+    assert "%23" in seen["raw_path"], \
+        f"'#' must be percent-encoded on the wire: {seen['raw_path']}"
+
+
+def test_already_encoded_hash_is_not_double_encoded():
+    responder, seen = _capture()
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+
+    asyncio.run(image_uri.resolve_image_uri("https://wb.example/a%23b.jpg"))
+
+    assert seen["path"].endswith("a#b.jpg"), seen["path"]
+    assert "%2523" not in seen["raw_path"], \
+        f"already-encoded '#' was encoded again: {seen['raw_path']}"
+
+
+def test_hash_in_filename_followed_by_a_signed_query():
+    """`/a#b.jpg?sig=...` is all fragment under URI parsing.
+
+    We deliberately reinterpret it as the producer means it -- a filename
+    containing '#', then a query -- so assert the exact wire target.
+    """
+    responder, seen = _capture()
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+
+    asyncio.run(image_uri.resolve_image_uri("https://wb.example/a#b.jpg?sig=xyz&t=1"))
+
+    assert seen["raw_path"] == "/a%23b.jpg?sig=xyz&t=1", seen["raw_path"]
+
+
+def test_genuine_fragment_after_a_real_query_is_left_as_a_fragment():
+    """A '#' that follows a real '?' is a fragment and must stay dropped."""
+    responder, seen = _capture()
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+
+    asyncio.run(image_uri.resolve_image_uri(
+        "https://wb.example/img.jpg?sig=xyz#fragment"))
+
+    assert seen["raw_path"] == "/img.jpg?sig=xyz", seen["raw_path"]
+
+
+def test_hash_in_the_authority_never_retargets_the_host():
+    """`https://evil#@internal.example/a.jpg` names host `evil`.
+
+    A blanket '#' -> '%23' turns it into userinfo `evil%23` on host
+    `internal.example`, silently sending a caller-supplied fetch somewhere
+    the URL never named. The path-only rule must leave it alone.
+    """
+    hostile = "https://evil#@internal.example/a.jpg"
+    assert image_uri.encode_bare_fragment(hostile) == hostile
+    assert httpx.URL(image_uri.encode_bare_fragment(hostile)).host == "evil"
+
+
+def test_local_path_with_hash_still_resolves(tmp_path, monkeypatch):
+    """A local filename containing '#' needs no encoding and must not get any."""
+    calls = []
+    monkeypatch.setattr(image_uri, "encode_bare_fragment",
+                        lambda u: calls.append(u) or u)
+    image_uri.init_image_fetch()
+    f = tmp_path / "2000_174419#R8123A.jpg"
+    f.write_bytes(PNG)
+
+    assert asyncio.run(image_uri.resolve_image_uri(str(f))) == PNG
+    assert calls == [], f"local path was passed through the URL normalizer: {calls}"
+
+
+def test_data_uri_never_reaches_the_normalizer(monkeypatch):
+    """Asserting the bytes come back proves nothing -- spy on the call."""
+    import base64
+    calls = []
+    monkeypatch.setattr(image_uri, "encode_bare_fragment",
+                        lambda u: calls.append(u) or u)
+    image_uri.init_image_fetch()
+    uri = "data:image/png;base64," + base64.b64encode(PNG).decode()
+
+    assert asyncio.run(image_uri.resolve_image_uri(uri)) == PNG
+    assert calls == [], f"data: URI was passed through the URL normalizer: {calls}"
+
+
+def test_ordinary_url_with_query_is_untouched():
+    """The common case must be byte-identical: no '#', nothing rewritten."""
+    responder, seen = _capture()
+    image_uri.init_image_fetch(transport=httpx.MockTransport(responder))
+
+    asyncio.run(image_uri.resolve_image_uri(
+        "https://wb.example/img.jpg?sig=xyz&expires=1"))
+
+    assert seen["raw_path"] == "/img.jpg?sig=xyz&expires=1", seen["raw_path"]
+
+
+def test_wbia_compat_loader_also_encodes_the_bare_hash():
+    """/wbia-compat has its own httpx.get and the identical exposure.
+
+    Fixing only the shared path would leave the same filenames unfetchable
+    through this router.
+    """
+    from unittest.mock import patch
+
+    from app.routers import wbia_compat_router
+
+    asked = {}
+
+    class _Resp:
+        content = PNG
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, **kw):
+        asked["url"] = str(url)
+        return _Resp()
+
+    with patch.object(wbia_compat_router.httpx, "get", fake_get):
+        data = wbia_compat_router._load_image(
+            "https://wb.example/wildbook_data_dir/3/c/uuid/2000_174419#R8123A.jpg")
+
+    assert data == PNG
+    assert "%23R8123A.jpg" in asked["url"], \
+        f"request would truncate at the '#': {asked['url']}"
+
+
+def test_scheme_relative_uri_is_returned_unchanged():
+    """Pins the contract: absolute http(s) only, no guessing.
+
+    Both call sites gate on an 'http://' / 'https://' prefix, so a
+    scheme-relative URI cannot reach the normalizer. It is left alone rather
+    than parsed heuristically.
+    """
+    assert image_uri.encode_bare_fragment("//h/a#b.jpg") == "//h/a#b.jpg"


### PR DESCRIPTION
## The bug

Production, Flukebook 2026-08-28 19:20:

```
httpx GET .../3c8f4264-.../2000_174419#R8123A.jpg "HTTP/1.1 404"
Image fetch failed (400, HTTPStatusError, 47 ms): .../2000_174419#R8123A.jpg
POST /extract/ 400 Bad Request
```

`#` opens a URL fragment, which is client-side only and never sent to the server. So httpx requested `/wildbook_data_dir/3/c/<uuid>/2000_174419` and Flukebook 404'd — the file is named `2000_174419#R8123A.jpg`. The 404 became a permanent 400, which Wildbook won't retry. That mapping was right; the request was wrong.

Wildbook builds these URLs without encoding the filename, which is the upstream half of this.

## The fix

`encode_bare_fragment()` percent-encodes `#` in the **path** of an http(s) URL. Applied in two places:

- `resolve_image_uri` — the shared path behind `/predict`, `/extract`, `/classify`, `/pipeline`, `/explain`
- `wbia_compat_router._load_image` — has its own `httpx.get` and the identical exposure

## Why it is not a one-line `replace`

My first version was `uri.replace('#', '%23')`. Codex caught that it can **retarget the request to a different host**, which I then reproduced:

```
https://evil#@internal.example/a.jpg
  host before: 'evil'
  host after : 'internal.example'   <-- blanket replace
```

`#` there terminates the authority, so encoding it promotes `evil#` to userinfo and sends a caller-supplied fetch somewhere the URL never named. In a service that fetches arbitrary caller-supplied URIs that is an SSRF vector, introduced by the fix rather than present before it.

The rule is structural instead: find the authority; unless the first delimiter after it is `/` — unless there is a path — return the URI untouched; otherwise encode `#` only up to the first `?`.

| input | path requested | query |
|---|---|---|
| `https://h/dir/2000_174419#R8123A.jpg` | `/dir/2000_174419%23R8123A.jpg` | — |
| `https://h/a#b.jpg?sig=x&t=1` | `/a%23b.jpg` | `sig=x&t=1` |
| `https://h/img.jpg?sig=x#frag` | `/img.jpg` | `sig=x` (fragment still drops) |
| `https://evil#@internal.example/a.jpg` | **unchanged**, host stays `evil` | — |
| `https://h/a%23b.jpg` | `/a%23b.jpg` (idempotent) | — |

Swept 18 URL shapes — userinfo, IPv6, ports, empty path, multiple `#`, `#` before and after `?`, already-encoded, mixed case. Zero host retargeting.

`data:` URIs and local paths never reach the normalizer, asserted with a spy rather than inferred from returned bytes.

## Trade-off, stated plainly

On a path-bearing URL a genuine trailing fragment is now read as part of the filename and will 404. A fragment is meaningless for a binary image fetch and Wildbook has no path that appends one, so this reading is right for the producers we serve. No non-heuristic rule separates the two intents.

## Deliberately not fixed

- **`?` has the same class of problem** — an unencoded `?` in a filename starts a query. But query strings are legitimate and common (signed URLs), so no safe general repair exists. Belongs where Wildbook builds the URL.
- **A redirect `Location` carrying a bare `#` still truncates.** The shared client follows redirects; normalizing each hop needs explicit per-hop handling. Narrow, and not needed for this regression.
- **Scheme-relative URIs** (`//h/a#b`) are returned unchanged. Both call sites gate on an `http(s)://` prefix so one cannot reach the helper; the contract is documented and pinned by a test rather than guessed at.

## Testing

`tests/test_image_fetch_bare_fragment.py`, 10 tests, 312 in the suite. Verified end to end against the exact production URL, with a transport that 404s unless the full filename arrives.

Per Codex round 1, two tests that passed vacuously were rewritten: the data-URI and local-path cases now spy on the normalizer instead of only checking returned bytes, and the signed-query case asserts the exact wire target rather than substring presence.

## Review

Codex (`codex exec`, gpt-5.6-terra), 2 rounds. Round 1: 2 Major — the host-retargeting flaw above, and `wbia_compat_router` (which it reviewed pre-fix; that landed mid-review). Round 2: converged for both call sites, one Minor on scheme-relative URLs, resolved by narrowing the documented contract.

🤖 Co-authored by [Claude Code](https://claude.com/claude-code) (Opus 5) and Codex (gpt-5.6-terra)